### PR TITLE
fix: remove unused ai package and update eslint-config-next to resolv…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
     "name": "yugiai",
-    "version": "0.1.0",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "yugiai",
-            "version": "0.1.0",
+            "version": "1.1.0",
             "dependencies": {
                 "@aws-sdk/client-bedrock-runtime": "^3.515.0",
                 "@vercel/analytics": "^1.5.0",
                 "@vercel/speed-insights": "^1.2.0",
-                "ai": "^4.1.46",
                 "bad-words": "^4.0.0",
                 "next": "^15.3.0",
                 "next-themes": "^0.2.1",
@@ -24,94 +23,10 @@
                 "@types/react-dom": "^18",
                 "autoprefixer": "^10.4.20",
                 "eslint": "^8",
-                "eslint-config-next": "14.0.4",
+                "eslint-config-next": "^15.5.15",
                 "postcss": "^8.5.3",
                 "tailwindcss": "^3.4.17",
                 "typescript": "^5"
-            }
-        },
-        "node_modules/@ai-sdk/provider": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.9.tgz",
-            "integrity": "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "json-schema": "^0.4.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@ai-sdk/provider-utils": {
-            "version": "2.1.10",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.10.tgz",
-            "integrity": "sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "1.0.9",
-                "eventsource-parser": "^3.0.0",
-                "nanoid": "^3.3.8",
-                "secure-json-parse": "^2.7.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "zod": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@ai-sdk/react": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.1.18.tgz",
-            "integrity": "sha512-2wlWug6NVAc8zh3pgqtvwPkSNTdA6Q4x9CmrNXCeHcXfJkJ+MuHFQz/I7Wb7mLRajf0DAxsFLIhHyBCEuTkDNw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider-utils": "2.1.10",
-                "@ai-sdk/ui-utils": "1.1.16",
-                "swr": "^2.2.5",
-                "throttleit": "2.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "react": "^18 || ^19 || ^19.0.0-rc",
-                "zod": "^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "react": {
-                    "optional": true
-                },
-                "zod": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@ai-sdk/ui-utils": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.1.16.tgz",
-            "integrity": "sha512-jfblR2yZVISmNK2zyNzJZFtkgX57WDAUQXcmn3XUBJyo8LFsADu+/vYMn5AOyBi9qJT0RBk11PEtIxIqvByw3Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "1.0.9",
-                "@ai-sdk/provider-utils": "2.1.10",
-                "zod-to-json-schema": "^3.24.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "zod": "^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "zod": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -267,480 +182,546 @@
             }
         },
         "node_modules/@aws-sdk/client-bedrock-runtime": {
-            "version": "3.755.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.755.0.tgz",
-            "integrity": "sha512-g5Adp2haJn3d1M7he4KSBUO/QAJuDNhnCNSZ4Ud30F0WvX07C7nZUDzKOi8cYa8xeXK6gpSlk6DdgcJflXdfXA==",
+            "version": "3.1030.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1030.0.tgz",
+            "integrity": "sha512-5Lnyx6mQPsIdld5Xr9FJqu8Hi9RVY6SgE8Rysmn4r3lRY2vNohNEu+gCtdXRDkkv/PgK9OnbA0sUPFU9rBRMYA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/credential-provider-node": "3.750.0",
-                "@aws-sdk/middleware-host-header": "3.734.0",
-                "@aws-sdk/middleware-logger": "3.734.0",
-                "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.750.0",
-                "@aws-sdk/region-config-resolver": "3.734.0",
-                "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.743.0",
-                "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.750.0",
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.4",
-                "@smithy/eventstream-serde-browser": "^4.0.1",
-                "@smithy/eventstream-serde-config-resolver": "^4.0.1",
-                "@smithy/eventstream-serde-node": "^4.0.1",
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/hash-node": "^4.0.1",
-                "@smithy/invalid-dependency": "^4.0.1",
-                "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.5",
-                "@smithy/middleware-retry": "^4.0.6",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.5",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.6",
-                "@smithy/util-defaults-mode-node": "^4.0.6",
-                "@smithy/util-endpoints": "^3.0.1",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
-                "@smithy/util-stream": "^4.1.1",
-                "@smithy/util-utf8": "^4.0.0",
-                "@types/uuid": "^9.0.1",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.750.0.tgz",
-            "integrity": "sha512-y0Rx6pTQXw0E61CaptpZF65qNggjqOgymq/RYZU5vWba5DGQ+iqGt8Yq8s+jfBoBBNXshxq8l8Dl5Uq/JTY1wg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/middleware-host-header": "3.734.0",
-                "@aws-sdk/middleware-logger": "3.734.0",
-                "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.750.0",
-                "@aws-sdk/region-config-resolver": "3.734.0",
-                "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.743.0",
-                "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.750.0",
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.4",
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/hash-node": "^4.0.1",
-                "@smithy/invalid-dependency": "^4.0.1",
-                "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.5",
-                "@smithy/middleware-retry": "^4.0.6",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.5",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.6",
-                "@smithy/util-defaults-mode-node": "^4.0.6",
-                "@smithy/util-endpoints": "^3.0.1",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
-                "@smithy/util-utf8": "^4.0.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/credential-provider-node": "^3.972.30",
+                "@aws-sdk/eventstream-handler-node": "^3.972.13",
+                "@aws-sdk/middleware-eventstream": "^3.972.9",
+                "@aws-sdk/middleware-host-header": "^3.972.9",
+                "@aws-sdk/middleware-logger": "^3.972.9",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+                "@aws-sdk/middleware-user-agent": "^3.972.29",
+                "@aws-sdk/middleware-websocket": "^3.972.15",
+                "@aws-sdk/region-config-resolver": "^3.972.11",
+                "@aws-sdk/token-providers": "3.1030.0",
+                "@aws-sdk/types": "^3.973.7",
+                "@aws-sdk/util-endpoints": "^3.996.6",
+                "@aws-sdk/util-user-agent-browser": "^3.972.9",
+                "@aws-sdk/util-user-agent-node": "^3.973.15",
+                "@smithy/config-resolver": "^4.4.14",
+                "@smithy/core": "^3.23.14",
+                "@smithy/eventstream-serde-browser": "^4.2.13",
+                "@smithy/eventstream-serde-config-resolver": "^4.3.13",
+                "@smithy/eventstream-serde-node": "^4.2.13",
+                "@smithy/fetch-http-handler": "^5.3.16",
+                "@smithy/hash-node": "^4.2.13",
+                "@smithy/invalid-dependency": "^4.2.13",
+                "@smithy/middleware-content-length": "^4.2.13",
+                "@smithy/middleware-endpoint": "^4.4.29",
+                "@smithy/middleware-retry": "^4.5.0",
+                "@smithy/middleware-serde": "^4.2.17",
+                "@smithy/middleware-stack": "^4.2.13",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/node-http-handler": "^4.5.2",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/smithy-client": "^4.12.9",
+                "@smithy/types": "^4.14.0",
+                "@smithy/url-parser": "^4.2.13",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.45",
+                "@smithy/util-defaults-mode-node": "^4.2.49",
+                "@smithy/util-endpoints": "^3.3.4",
+                "@smithy/util-middleware": "^4.2.13",
+                "@smithy/util-retry": "^4.3.0",
+                "@smithy/util-stream": "^4.5.22",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.750.0.tgz",
-            "integrity": "sha512-bZ5K7N5L4+Pa2epbVpUQqd1XLG2uU8BGs/Sd+2nbgTf+lNQJyIxAg/Qsrjz9MzmY8zzQIeRQEkNmR6yVAfCmmQ==",
+            "version": "3.973.27",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+            "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/core": "^3.1.4",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/signature-v4": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.5",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-middleware": "^4.0.1",
-                "fast-xml-parser": "4.4.1",
+                "@aws-sdk/types": "^3.973.7",
+                "@aws-sdk/xml-builder": "^3.972.17",
+                "@smithy/core": "^3.23.14",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/signature-v4": "^5.3.13",
+                "@smithy/smithy-client": "^4.12.9",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-middleware": "^4.2.13",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.750.0.tgz",
-            "integrity": "sha512-In6bsG0p/P31HcH4DBRKBbcDS/3SHvEPjfXV8ODPWZO/l3/p7IRoYBdQ07C9R+VMZU2D0+/Sc/DWK/TUNDk1+Q==",
+            "version": "3.972.25",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
+            "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.750.0.tgz",
-            "integrity": "sha512-wFB9qqfa20AB0dElsQz5ZlZT5o+a+XzpEpmg0erylmGYqEOvh8NQWfDUVpRmQuGq9VbvW/8cIbxPoNqEbPtuWQ==",
+            "version": "3.972.27",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
+            "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.5",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-stream": "^4.1.1",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/fetch-http-handler": "^5.3.16",
+                "@smithy/node-http-handler": "^4.5.2",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/smithy-client": "^4.12.9",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-stream": "^4.5.22",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.750.0.tgz",
-            "integrity": "sha512-2YIZmyEr5RUd3uxXpxOLD9G67Bibm4I/65M6vKFP17jVMUT+R1nL7mKqmhEVO2p+BoeV+bwMyJ/jpTYG368PCg==",
+            "version": "3.972.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
+            "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/credential-provider-env": "3.750.0",
-                "@aws-sdk/credential-provider-http": "3.750.0",
-                "@aws-sdk/credential-provider-process": "3.750.0",
-                "@aws-sdk/credential-provider-sso": "3.750.0",
-                "@aws-sdk/credential-provider-web-identity": "3.750.0",
-                "@aws-sdk/nested-clients": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/credential-provider-imds": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/credential-provider-env": "^3.972.25",
+                "@aws-sdk/credential-provider-http": "^3.972.27",
+                "@aws-sdk/credential-provider-login": "^3.972.29",
+                "@aws-sdk/credential-provider-process": "^3.972.25",
+                "@aws-sdk/credential-provider-sso": "^3.972.29",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+                "@aws-sdk/nested-clients": "^3.996.19",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/credential-provider-imds": "^4.2.13",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
+            "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/nested-clients": "^3.996.19",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.750.0.tgz",
-            "integrity": "sha512-THWHHAceLwsOiowPEmKyhWVDlEUxH07GHSw5AQFDvNQtGKOQl0HSIFO1mKObT2Q2Vqzji9Bq8H58SO5BFtNPRw==",
+            "version": "3.972.30",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+            "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.750.0",
-                "@aws-sdk/credential-provider-http": "3.750.0",
-                "@aws-sdk/credential-provider-ini": "3.750.0",
-                "@aws-sdk/credential-provider-process": "3.750.0",
-                "@aws-sdk/credential-provider-sso": "3.750.0",
-                "@aws-sdk/credential-provider-web-identity": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/credential-provider-imds": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/credential-provider-env": "^3.972.25",
+                "@aws-sdk/credential-provider-http": "^3.972.27",
+                "@aws-sdk/credential-provider-ini": "^3.972.29",
+                "@aws-sdk/credential-provider-process": "^3.972.25",
+                "@aws-sdk/credential-provider-sso": "^3.972.29",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/credential-provider-imds": "^4.2.13",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.750.0.tgz",
-            "integrity": "sha512-Q78SCH1n0m7tpu36sJwfrUSxI8l611OyysjQeMiIOliVfZICEoHcLHLcLkiR+tnIpZ3rk7d2EQ6R1jwlXnalMQ==",
+            "version": "3.972.25",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
+            "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.750.0.tgz",
-            "integrity": "sha512-FGYrDjXN/FOQVi/t8fHSv8zCk+NEvtFnuc4cZUj5OIbM4vrfFc5VaPyn41Uza3iv6Qq9rZg0QOwWnqK8lNrqUw==",
+            "version": "3.972.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
+            "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.750.0",
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/token-providers": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/nested-clients": "^3.996.19",
+                "@aws-sdk/token-providers": "3.1026.0",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+            "version": "3.1026.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+            "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/nested-clients": "^3.996.19",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.750.0.tgz",
-            "integrity": "sha512-Nz8zs3YJ+GOTSrq+LyzbbC1Ffpt7pK38gcOyNZv76pP5MswKTUKNYBJehqwa+i7FcFQHsCk3TdhR8MT1ZR23uA==",
+            "version": "3.972.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
+            "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/nested-clients": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/nested-clients": "^3.996.19",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-handler-node": {
+            "version": "3.972.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.13.tgz",
+            "integrity": "sha512-2Pi1kD0MDkMAxDHqvpi/hKMs9hXUYbj2GLEjCwy+0jzfLChAsF50SUYnOeTI+RztA+Ic4pnLAdB03f1e8nggxQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/eventstream-codec": "^4.2.13",
+                "@smithy/types": "^4.14.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-eventstream": {
+            "version": "3.972.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.9.tgz",
+            "integrity": "sha512-ypgOvpWxQTCnQyDHGxnTviqqANE7FIIzII7VczJnTPCJcJlu17hMQXnvE47aKSKsawVJAaaRsyOEbHQuLJF9ng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
-            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "version": "3.972.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
+            "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
-            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "version": "3.972.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
+            "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
-            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
+            "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "^3.973.7",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.750.0.tgz",
-            "integrity": "sha512-YYcslDsP5+2NZoN3UwuhZGkhAHPSli7HlJHBafBrvjGV/I9f8FuOO1d1ebxGdEP4HyRXUGyh+7Ur4q+Psk0ryw==",
+            "version": "3.972.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
+            "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.743.0",
-                "@smithy/core": "^3.1.4",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/types": "^3.973.7",
+                "@aws-sdk/util-endpoints": "^3.996.6",
+                "@smithy/core": "^3.23.14",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-retry": "^4.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-websocket": {
+            "version": "3.972.15",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.15.tgz",
+            "integrity": "sha512-hsZ35FORQsN5hwNdMD6zWmHCphbXkDxO6j+xwCUiuMb0O6gzS/PWgttQNl1OAn7h/uqZAMUG4yOS0wY/yhAieg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.7",
+                "@aws-sdk/util-format-url": "^3.972.9",
+                "@smithy/eventstream-codec": "^4.2.13",
+                "@smithy/eventstream-serde-browser": "^4.2.13",
+                "@smithy/fetch-http-handler": "^5.3.16",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/signature-v4": "^5.3.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.750.0.tgz",
-            "integrity": "sha512-OH68BRF0rt9nDloq4zsfeHI0G21lj11a66qosaljtEP66PWm7tQ06feKbFkXHT5E1K3QhJW3nVyK8v2fEBY5fg==",
+            "version": "3.996.19",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
+            "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.750.0",
-                "@aws-sdk/middleware-host-header": "3.734.0",
-                "@aws-sdk/middleware-logger": "3.734.0",
-                "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.750.0",
-                "@aws-sdk/region-config-resolver": "3.734.0",
-                "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.743.0",
-                "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.750.0",
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.4",
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/hash-node": "^4.0.1",
-                "@smithy/invalid-dependency": "^4.0.1",
-                "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.5",
-                "@smithy/middleware-retry": "^4.0.6",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.5",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.6",
-                "@smithy/util-defaults-mode-node": "^4.0.6",
-                "@smithy/util-endpoints": "^3.0.1",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
-                "@smithy/util-utf8": "^4.0.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/middleware-host-header": "^3.972.9",
+                "@aws-sdk/middleware-logger": "^3.972.9",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+                "@aws-sdk/middleware-user-agent": "^3.972.29",
+                "@aws-sdk/region-config-resolver": "^3.972.11",
+                "@aws-sdk/types": "^3.973.7",
+                "@aws-sdk/util-endpoints": "^3.996.6",
+                "@aws-sdk/util-user-agent-browser": "^3.972.9",
+                "@aws-sdk/util-user-agent-node": "^3.973.15",
+                "@smithy/config-resolver": "^4.4.14",
+                "@smithy/core": "^3.23.14",
+                "@smithy/fetch-http-handler": "^5.3.16",
+                "@smithy/hash-node": "^4.2.13",
+                "@smithy/invalid-dependency": "^4.2.13",
+                "@smithy/middleware-content-length": "^4.2.13",
+                "@smithy/middleware-endpoint": "^4.4.29",
+                "@smithy/middleware-retry": "^4.5.0",
+                "@smithy/middleware-serde": "^4.2.17",
+                "@smithy/middleware-stack": "^4.2.13",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/node-http-handler": "^4.5.2",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/smithy-client": "^4.12.9",
+                "@smithy/types": "^4.14.0",
+                "@smithy/url-parser": "^4.2.13",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.45",
+                "@smithy/util-defaults-mode-node": "^4.2.49",
+                "@smithy/util-endpoints": "^3.3.4",
+                "@smithy/util-middleware": "^4.2.13",
+                "@smithy/util-retry": "^4.3.0",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
-            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "version": "3.972.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
+            "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-config-provider": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/config-resolver": "^4.4.14",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.750.0.tgz",
-            "integrity": "sha512-X/KzqZw41iWolwNdc8e3RMcNSMR364viHv78u6AefXOO5eRM40c4/LuST1jDzq35/LpnqRhL7/MuixOetw+sFw==",
+            "version": "3.1030.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1030.0.tgz",
+            "integrity": "sha512-gUuCLTnEiUgpxHEnJSidxZZlQ+rQwc/mrijz6DxeMijTwS3/e3UfJvL8C1YDvcbt8MkkXj92h0MpYtfhR+EGeg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/nested-clients": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "^3.973.27",
+                "@aws-sdk/nested-clients": "^3.996.19",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "version": "3.973.7",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+            "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.743.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "version": "3.996.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
+            "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-endpoints": "^3.0.1",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/types": "^4.14.0",
+                "@smithy/url-parser": "^4.2.13",
+                "@smithy/util-endpoints": "^3.3.4",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-format-url": {
+            "version": "3.972.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.9.tgz",
+            "integrity": "sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/querystring-builder": "^4.2.13",
+                "@smithy/types": "^4.14.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
-            "integrity": "sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==",
+            "version": "3.965.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+            "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
-            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "version": "3.972.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
+            "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/types": "^4.14.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.750.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.750.0.tgz",
-            "integrity": "sha512-84HJj9G9zbrHX2opLk9eHfDceB+UIHVrmflMzWHpsmo9fDuro/flIBqaVDlE021Osj6qIM0SJJcnL6s23j7JEw==",
+            "version": "3.973.15",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
+            "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.750.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/middleware-user-agent": "^3.972.29",
+                "@aws-sdk/types": "^3.973.7",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-config-provider": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "aws-crt": ">=1.0.0"
@@ -751,10 +732,33 @@
                 }
             }
         },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.17",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+            "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.0",
+                "fast-xml-parser": "5.5.8",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+            "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@emnapi/runtime": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.1.tgz",
-            "integrity": "sha512-LMshMVP0ZhACNjQNYXiU1iZJ6QCcv0lUdPDPugqGvCGXt5xtRVBPdtA0qU12pEXZzpWAhWlZYptfdAFq10DOVQ==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -762,9 +766,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -781,9 +785,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -862,10 +866,20 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.1.tgz",
-            "integrity": "sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
             "cpu": [
                 "arm64"
             ],
@@ -881,13 +895,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.1.0"
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.1.tgz",
-            "integrity": "sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
             "cpu": [
                 "x64"
             ],
@@ -903,13 +917,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.1.0"
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz",
-            "integrity": "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
             "cpu": [
                 "arm64"
             ],
@@ -923,9 +937,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.1.0.tgz",
-            "integrity": "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
             "cpu": [
                 "x64"
             ],
@@ -939,11 +953,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.1.0.tgz",
-            "integrity": "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -955,11 +972,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.1.0.tgz",
-            "integrity": "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -971,11 +991,33 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz",
-            "integrity": "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -987,11 +1029,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.1.0.tgz",
-            "integrity": "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1003,11 +1048,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz",
-            "integrity": "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1019,11 +1067,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.1.0.tgz",
-            "integrity": "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1035,11 +1086,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz",
-            "integrity": "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1051,12 +1105,15 @@
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.1.tgz",
-            "integrity": "sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1069,15 +1126,18 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.1.0"
+                "@img/sharp-libvips-linux-arm": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.1.tgz",
-            "integrity": "sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1091,16 +1151,69 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.1.0"
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.1.tgz",
-            "integrity": "sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1113,15 +1226,18 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.1.0"
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.1.tgz",
-            "integrity": "sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1135,16 +1251,19 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.1.0"
+                "@img/sharp-libvips-linux-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.1.tgz",
-            "integrity": "sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1157,15 +1276,18 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.1.0"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.1.tgz",
-            "integrity": "sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1179,21 +1301,40 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.1.0"
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.1.tgz",
-            "integrity": "sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
             "cpu": [
                 "wasm32"
             ],
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.4.0"
+                "@emnapi/runtime": "^1.7.0"
             },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1202,9 +1343,9 @@
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.1.tgz",
-            "integrity": "sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
             "cpu": [
                 "ia32"
             ],
@@ -1221,9 +1362,9 @@
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.1.tgz",
-            "integrity": "sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
             "cpu": [
                 "x64"
             ],
@@ -1340,25 +1481,55 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.0.tgz",
-            "integrity": "sha512-6mDmHX24nWlHOlbwUiAOmMyY7KELimmi+ed8qWcJYjqXeC+G6JzPZ3QosOAfjNwgMIzwhXBiRiCgdh8axTTdTA==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+            "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.4.tgz",
-            "integrity": "sha512-U3qMNHmEZoVmHA0j/57nRfi3AscXNvkOnxDmle/69Jz/G0o/gWjXTDdlgILZdrxQ0Lw/jv2mPW8PGy0EGIHXhQ==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.15.tgz",
+            "integrity": "sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "glob": "7.1.7"
+                "fast-glob": "3.3.1"
+            }
+        },
+        "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.0.tgz",
-            "integrity": "sha512-PDQcByT0ZfF2q7QR9d+PNj3wlNN4K6Q8JoHMwFyk252gWo4gKt7BF8Y2+KBgDjTFBETXZ/TkBEUY7NIIY7A/Kw==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+            "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
             "cpu": [
                 "arm64"
             ],
@@ -1372,9 +1543,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.0.tgz",
-            "integrity": "sha512-m+eO21yg80En8HJ5c49AOQpFDq+nP51nu88ZOMCorvw3g//8g1JSUsEiPSiFpJo1KCTQ+jm9H0hwXK49H/RmXg==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+            "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
             "cpu": [
                 "x64"
             ],
@@ -1388,11 +1559,14 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.0.tgz",
-            "integrity": "sha512-H0Kk04ZNzb6Aq/G6e0un4B3HekPnyy6D+eUBYPJv9Abx8KDYgNMWzKt4Qhj57HXV3sTTjsfc1Trc1SxuhQB+Tg==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+            "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1404,11 +1578,14 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.0.tgz",
-            "integrity": "sha512-k8GVkdMrh/+J9uIv/GpnHakzgDQhrprJ/FbGQvwWmstaeFG06nnAoZCJV+wO/bb603iKV1BXt4gHG+s2buJqZA==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+            "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1420,11 +1597,14 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.0.tgz",
-            "integrity": "sha512-ZMQ9yzDEts/vkpFLRAqfYO1wSpIJGlQNK9gZ09PgyjBJUmg8F/bb8fw2EXKgEaHbCc4gmqMpDfh+T07qUphp9A==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+            "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1436,11 +1616,14 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.0.tgz",
-            "integrity": "sha512-RFwq5VKYTw9TMr4T3e5HRP6T4RiAzfDJ6XsxH8j/ZeYq2aLsBqCkFzwMI0FmnSsLaUbOb46Uov0VvN3UciHX5A==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+            "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1452,9 +1635,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.0.tgz",
-            "integrity": "sha512-a7kUbqa/k09xPjfCl0RSVAvEjAkYBYxUzSVAzk2ptXiNEL+4bDBo9wNC43G/osLA/EOGzG4CuNRFnQyIHfkRgQ==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+            "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
             "cpu": [
                 "arm64"
             ],
@@ -1468,9 +1651,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.0.tgz",
-            "integrity": "sha512-vHUQS4YVGJPmpjn7r5lEZuMhK5UQBNBRSB+iGDvJjaNk649pTIcRluDWNb9siunyLLiu/LDPHfvxBtNamyuLTw==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+            "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
             "cpu": [
                 "x64"
             ],
@@ -1531,15 +1714,6 @@
                 "node": ">=12.4.0"
             }
         },
-        "node_modules/@opentelemetry/api": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1565,29 +1739,17 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@smithy/abort-controller": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/@smithy/config-resolver": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "version": "4.4.15",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.15.tgz",
+            "integrity": "sha512-BJdMBY5YO9iHh+lPLYdHv6LbX+J8IcPCYMl1IJdBt2KDWNHwONHrPVHk3ttYBqJd9wxv84wlbN0f7GlQzcQtNQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-config-provider": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-endpoints": "^3.4.0",
+                "@smithy/util-middleware": "^4.2.13",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1595,18 +1757,20 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "version": "3.23.14",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
+            "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-stream": "^4.1.2",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/url-parser": "^4.2.13",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.13",
+                "@smithy/util-stream": "^4.5.22",
+                "@smithy/util-utf8": "^4.2.2",
+                "@smithy/uuid": "^1.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1614,15 +1778,15 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
+            "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/url-parser": "^4.2.13",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1630,14 +1794,14 @@
             }
         },
         "node_modules/@smithy/eventstream-codec": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.1.tgz",
-            "integrity": "sha512-Q2bCAAR6zXNVtJgifsU16ZjKGqdw/DyecKNgIgi7dlqw04fqDu0mnq+JmGphqheypVc64CYq3azSuCpAdFk2+A==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
+            "integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/crc32": "5.2.0",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-hex-encoding": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1645,13 +1809,13 @@
             }
         },
         "node_modules/@smithy/eventstream-serde-browser": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.1.tgz",
-            "integrity": "sha512-HbIybmz5rhNg+zxKiyVAnvdM3vkzjE6ccrJ620iPL8IXcJEntd3hnBl+ktMwIy12Te/kyrSbUb8UCdnUT4QEdA==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
+            "integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/eventstream-serde-universal": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/eventstream-serde-universal": "^4.2.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1659,12 +1823,12 @@
             }
         },
         "node_modules/@smithy/eventstream-serde-config-resolver": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.0.1.tgz",
-            "integrity": "sha512-lSipaiq3rmHguHa3QFF4YcCM3VJOrY9oq2sow3qlhFY+nBSTF/nrO82MUQRPrxHQXA58J5G1UnU2WuJfi465BA==",
+            "version": "4.3.13",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
+            "integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1672,13 +1836,13 @@
             }
         },
         "node_modules/@smithy/eventstream-serde-node": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
-            "integrity": "sha512-o4CoOI6oYGYJ4zXo34U8X9szDe3oGjmHgsMGiZM0j4vtNoT+h80TLnkUcrLZR3+E6HIxqW+G+9WHAVfl0GXK0Q==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
+            "integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/eventstream-serde-universal": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/eventstream-serde-universal": "^4.2.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1686,13 +1850,13 @@
             }
         },
         "node_modules/@smithy/eventstream-serde-universal": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.1.tgz",
-            "integrity": "sha512-Z94uZp0tGJuxds3iEAZBqGU2QiaBHP4YytLUjwZWx+oUeohCsLyUm33yp4MMBmhkuPqSbQCXq5hDet6JGUgHWA==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
+            "integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/eventstream-codec": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/eventstream-codec": "^4.2.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1700,15 +1864,15 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "version": "5.3.16",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
+            "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/querystring-builder": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-base64": "^4.0.0",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/querystring-builder": "^4.2.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-base64": "^4.3.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1716,14 +1880,14 @@
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
+            "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-buffer-from": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1731,12 +1895,12 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
+            "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1744,9 +1908,9 @@
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+            "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -1756,13 +1920,13 @@
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
+            "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1770,18 +1934,18 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "version": "4.4.29",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
+            "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.1.5",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/core": "^3.23.14",
+                "@smithy/middleware-serde": "^4.2.17",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
+                "@smithy/url-parser": "^4.2.13",
+                "@smithy/util-middleware": "^4.2.13",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1789,32 +1953,35 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-            "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.1.tgz",
+            "integrity": "sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/service-error-classification": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
+                "@smithy/core": "^3.23.14",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/service-error-classification": "^4.2.13",
+                "@smithy/smithy-client": "^4.12.9",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-middleware": "^4.2.13",
+                "@smithy/util-retry": "^4.3.1",
+                "@smithy/uuid": "^1.1.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "version": "4.2.17",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
+            "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/core": "^3.23.14",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1822,12 +1989,12 @@
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
+            "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1835,14 +2002,14 @@
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "version": "4.3.13",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
+            "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/shared-ini-file-loader": "^4.4.8",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1850,15 +2017,14 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
+            "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/querystring-builder": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/querystring-builder": "^4.2.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1866,12 +2032,12 @@
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
+            "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1879,12 +2045,12 @@
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "version": "5.3.13",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+            "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1892,13 +2058,13 @@
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
+            "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-uri-escape": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1906,12 +2072,12 @@
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
+            "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1919,24 +2085,24 @@
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
+            "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0"
+                "@smithy/types": "^4.14.0"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
+            "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1944,18 +2110,18 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "version": "5.3.13",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+            "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-hex-encoding": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-uri-escape": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/is-array-buffer": "^4.2.2",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.13",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1963,17 +2129,17 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "version": "4.12.9",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
+            "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.1.5",
-                "@smithy/middleware-endpoint": "^4.0.6",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-stream": "^4.1.2",
+                "@smithy/core": "^3.23.14",
+                "@smithy/middleware-endpoint": "^4.4.29",
+                "@smithy/middleware-stack": "^4.2.13",
+                "@smithy/protocol-http": "^5.3.13",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-stream": "^4.5.22",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1981,9 +2147,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+            "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -1993,13 +2159,13 @@
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
+            "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/querystring-parser": "^4.2.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2007,13 +2173,13 @@
             }
         },
         "node_modules/@smithy/util-base64": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+            "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2021,9 +2187,9 @@
             }
         },
         "node_modules/@smithy/util-body-length-browser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+            "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -2033,9 +2199,9 @@
             }
         },
         "node_modules/@smithy/util-body-length-node": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+            "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -2045,12 +2211,12 @@
             }
         },
         "node_modules/@smithy/util-buffer-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+            "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/is-array-buffer": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2058,9 +2224,9 @@
             }
         },
         "node_modules/@smithy/util-config-provider": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+            "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -2070,15 +2236,14 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-            "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+            "version": "4.3.45",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
+            "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "bowser": "^2.11.0",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/smithy-client": "^4.12.9",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2086,17 +2251,17 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-            "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+            "version": "4.2.50",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.50.tgz",
+            "integrity": "sha512-xpjncL5XozFA3No7WypTsPU1du0fFS8flIyO+Wh2nhCy7bpEapvU7BR55Bg+wrfw+1cRA+8G8UsTjaxgzrMzXg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/credential-provider-imds": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
+                "@smithy/config-resolver": "^4.4.15",
+                "@smithy/credential-provider-imds": "^4.2.13",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/property-provider": "^4.2.13",
+                "@smithy/smithy-client": "^4.12.9",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2104,13 +2269,13 @@
             }
         },
         "node_modules/@smithy/util-endpoints": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.0.tgz",
+            "integrity": "sha512-QQHGPKkw6NPcU6TJ1rNEEa201srPtZiX4k61xL163vvs9sTqW/XKz+UEuJ00uvPqoN+5Rs4Ka1UJ7+Mp03IXJw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/node-config-provider": "^4.3.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2118,9 +2283,9 @@
             }
         },
         "node_modules/@smithy/util-hex-encoding": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+            "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -2130,12 +2295,12 @@
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "version": "4.2.13",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
+            "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2143,13 +2308,13 @@
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.1.tgz",
+            "integrity": "sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/service-error-classification": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/service-error-classification": "^4.2.13",
+                "@smithy/types": "^4.14.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2157,18 +2322,18 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-            "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+            "version": "4.5.22",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
+            "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/node-http-handler": "^4.0.3",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-buffer-from": "^4.0.0",
-                "@smithy/util-hex-encoding": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/fetch-http-handler": "^5.3.16",
+                "@smithy/node-http-handler": "^4.5.2",
+                "@smithy/types": "^4.14.0",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2176,9 +2341,9 @@
             }
         },
         "node_modules/@smithy/util-uri-escape": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+            "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -2188,23 +2353,29 @@
             }
         },
         "node_modules/@smithy/util-utf8": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@swc/counter": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "license": "Apache-2.0"
+        "node_modules/@smithy/uuid": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+            "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
@@ -2214,12 +2385,6 @@
             "dependencies": {
                 "tslib": "^2.8.0"
             }
-        },
-        "node_modules/@types/diff-match-patch": {
-            "version": "1.0.36",
-            "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-            "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
-            "license": "MIT"
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -2266,67 +2431,160 @@
                 "@types/react": "^18.0.0"
             }
         },
-        "node_modules/@types/uuid": {
-            "version": "9.0.8",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-            "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-            "license": "MIT"
-        },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-            "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+            "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
             "dev": true,
-            "license": "BSD-2-Clause",
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
-                "debug": "^4.3.4"
+                "@eslint-community/regexpp": "^4.12.2",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/type-utils": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
+                "ignore": "^7.0.5",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "@typescript-eslint/parser": "^8.58.2",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+            "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0"
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
+                "debug": "^4.4.3"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+            "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.58.2",
+                "@typescript-eslint/types": "^8.58.2",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+            "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+            "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+            "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2",
+                "debug": "^4.4.3",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+            "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2334,76 +2592,125 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+            "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
             "dev": true,
-            "license": "BSD-2-Clause",
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "minimatch": "9.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
+                "@typescript-eslint/project-service": "8.58.2",
+                "@typescript-eslint/tsconfig-utils": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "eslint-visitor-keys": "^3.4.1"
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+            "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.58.2",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -2509,39 +2816,10 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
-        "node_modules/ai": {
-            "version": "4.1.46",
-            "resolved": "https://registry.npmjs.org/ai/-/ai-4.1.46.tgz",
-            "integrity": "sha512-VTvAktT69IN1qcNAv7OlcOuR0q4HqUlhkVacrWmMlEoprYykF9EL5RY8IECD5d036Wqg0walwbSKZlA2noHm1A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ai-sdk/provider": "1.0.9",
-                "@ai-sdk/provider-utils": "2.1.10",
-                "@ai-sdk/react": "1.1.18",
-                "@ai-sdk/ui-utils": "1.1.16",
-                "@opentelemetry/api": "1.9.0",
-                "jsondiffpatch": "0.6.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "react": "^18 || ^19 || ^19.0.0-rc",
-                "zod": "^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "react": {
-                    "optional": true
-                },
-                "zod": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2662,16 +2940,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/array.prototype.findlast": {
@@ -2923,15 +3191,15 @@
             }
         },
         "node_modules/bowser": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+            "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2983,17 +3251,6 @@
             },
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "node_modules/busboy": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "dependencies": {
-                "streamsearch": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=10.16.0"
             }
         },
         "node_modules/call-bind": {
@@ -3147,25 +3404,11 @@
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
             "license": "MIT"
         },
-        "node_modules/color": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "color-convert": "^2.0.1",
-                "color-string": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=12.5.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -3178,19 +3421,8 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
-        },
-        "node_modules/color-string": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
         },
         "node_modules/commander": {
             "version": "4.1.1",
@@ -3306,9 +3538,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3366,19 +3598,10 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/dequal": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/detect-libc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "license": "Apache-2.0",
             "optional": true,
             "engines": {
@@ -3391,25 +3614,6 @@
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
             "dev": true,
             "license": "Apache-2.0"
-        },
-        "node_modules/diff-match-patch": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/dlv": {
             "version": "1.1.3",
@@ -3736,24 +3940,25 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.0.4.tgz",
-            "integrity": "sha512-9/xbOHEQOmQtqvQ1UsTQZpnA7SlDMBtuKJ//S4JnoyK3oGLhILKXdBgu/UO7lQo/2xOykQULS1qQ6p2+EpHgAQ==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.15.tgz",
+            "integrity": "sha512-mI5KIONOIosjF3jK2z9a8fY2LePNeW5C4lRJ+XZoJHAKkwx2MQjMPQ2/kL7tsMRPcQPZc/UBtCfqxElluL1CBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@next/eslint-plugin-next": "14.0.4",
-                "@rushstack/eslint-patch": "^1.3.3",
-                "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
+                "@next/eslint-plugin-next": "15.5.15",
+                "@rushstack/eslint-patch": "^1.10.3",
+                "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+                "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
-                "eslint-plugin-import": "^2.28.1",
-                "eslint-plugin-jsx-a11y": "^6.7.1",
-                "eslint-plugin-react": "^7.33.2",
-                "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+                "eslint-plugin-import": "^2.31.0",
+                "eslint-plugin-jsx-a11y": "^6.10.0",
+                "eslint-plugin-react": "^7.37.0",
+                "eslint-plugin-react-hooks": "^5.0.0"
             },
             "peerDependencies": {
-                "eslint": "^7.23.0 || ^8.0.0",
+                "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
                 "typescript": ">=3.3.1"
             },
             "peerDependenciesMeta": {
@@ -3978,16 +4183,16 @@
             }
         },
         "node_modules/eslint-plugin-react-hooks": {
-            "version": "5.0.0-canary-7118f5dd7-20230705",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
-            "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+            "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
             "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
             }
         },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -4125,15 +4330,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/eventsource-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
-            "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4185,23 +4381,36 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-xml-parser": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+        "node_modules/fast-xml-builder": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
                 }
             ],
             "license": "MIT",
             "dependencies": {
-                "strnum": "^1.0.5"
+                "path-expression-matcher": "^1.1.3"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.5.8",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+            "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "fast-xml-builder": "^1.1.4",
+                "path-expression-matcher": "^1.2.0",
+                "strnum": "^2.2.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -4276,9 +4485,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -4530,27 +4739,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4760,13 +4948,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/is-arrayish": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/is-async-function": {
             "version": "2.1.1",
@@ -5236,9 +5417,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5254,12 +5435,6 @@
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-            "license": "(AFL-2.1 OR BSD-3-Clause)"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -5286,35 +5461,6 @@
             },
             "bin": {
                 "json5": "lib/cli.js"
-            }
-        },
-        "node_modules/jsondiffpatch": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-            "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/diff-match-patch": "^1.0.36",
-                "chalk": "^5.3.0",
-                "diff-match-patch": "^1.0.5"
-            },
-            "bin": {
-                "jsondiffpatch": "bin/jsondiffpatch.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            }
-        },
-        "node_modules/jsondiffpatch/node_modules/chalk": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -5474,9 +5620,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5551,15 +5697,13 @@
             "license": "MIT"
         },
         "node_modules/next": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.3.0.tgz",
-            "integrity": "sha512-k0MgP6BsK8cZ73wRjMazl2y2UcXj49ZXLDEgx6BikWuby/CN+nh81qFFI16edgd7xYpe/jj2OZEIwCoqnzz0bQ==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+            "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "15.3.0",
-                "@swc/counter": "0.1.3",
+                "@next/env": "15.5.15",
                 "@swc/helpers": "0.5.15",
-                "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "8.4.31",
                 "styled-jsx": "5.1.6"
@@ -5571,19 +5715,19 @@
                 "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "15.3.0",
-                "@next/swc-darwin-x64": "15.3.0",
-                "@next/swc-linux-arm64-gnu": "15.3.0",
-                "@next/swc-linux-arm64-musl": "15.3.0",
-                "@next/swc-linux-x64-gnu": "15.3.0",
-                "@next/swc-linux-x64-musl": "15.3.0",
-                "@next/swc-win32-arm64-msvc": "15.3.0",
-                "@next/swc-win32-x64-msvc": "15.3.0",
-                "sharp": "^0.34.1"
+                "@next/swc-darwin-arm64": "15.5.15",
+                "@next/swc-darwin-x64": "15.5.15",
+                "@next/swc-linux-arm64-gnu": "15.5.15",
+                "@next/swc-linux-arm64-musl": "15.5.15",
+                "@next/swc-linux-x64-gnu": "15.5.15",
+                "@next/swc-linux-x64-musl": "15.5.15",
+                "@next/swc-win32-arm64-msvc": "15.5.15",
+                "@next/swc-win32-x64-msvc": "15.5.15",
+                "sharp": "^0.34.3"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
-                "@playwright/test": "^1.41.2",
+                "@playwright/test": "^1.51.1",
                 "babel-plugin-react-compiler": "*",
                 "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
                 "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
@@ -5910,6 +6054,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -5954,16 +6113,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5971,9 +6120,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6472,16 +6621,10 @@
                 "loose-envify": "^1.1.0"
             }
         },
-        "node_modules/secure-json-parse": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-            "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "devOptional": true,
             "license": "ISC",
             "bin": {
@@ -6541,16 +6684,16 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.1.tgz",
-            "integrity": "sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "color": "^4.2.3",
-                "detect-libc": "^2.0.3",
-                "semver": "^7.7.1"
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
             },
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -6559,26 +6702,30 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.34.1",
-                "@img/sharp-darwin-x64": "0.34.1",
-                "@img/sharp-libvips-darwin-arm64": "1.1.0",
-                "@img/sharp-libvips-darwin-x64": "1.1.0",
-                "@img/sharp-libvips-linux-arm": "1.1.0",
-                "@img/sharp-libvips-linux-arm64": "1.1.0",
-                "@img/sharp-libvips-linux-ppc64": "1.1.0",
-                "@img/sharp-libvips-linux-s390x": "1.1.0",
-                "@img/sharp-libvips-linux-x64": "1.1.0",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
-                "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
-                "@img/sharp-linux-arm": "0.34.1",
-                "@img/sharp-linux-arm64": "0.34.1",
-                "@img/sharp-linux-s390x": "0.34.1",
-                "@img/sharp-linux-x64": "0.34.1",
-                "@img/sharp-linuxmusl-arm64": "0.34.1",
-                "@img/sharp-linuxmusl-x64": "0.34.1",
-                "@img/sharp-wasm32": "0.34.1",
-                "@img/sharp-win32-ia32": "0.34.1",
-                "@img/sharp-win32-x64": "0.34.1"
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
             }
         },
         "node_modules/shebang-command": {
@@ -6693,26 +6840,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "is-arrayish": "^0.3.1"
-            }
-        },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6728,14 +6855,6 @@
             "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/streamsearch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
         },
         "node_modules/string-width": {
             "version": "5.1.2",
@@ -6971,9 +7090,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.1.tgz",
-            "integrity": "sha512-O7aCHfYCamLCctjAiaucmE+fHf2DYHkus2OKCn4Wv03sykfFtgeECn505X6K4mPl8CRNd/qurC9guq+ynoN4pw==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
             "funding": [
                 {
                     "type": "github",
@@ -7029,9 +7148,9 @@
             }
         },
         "node_modules/sucrase/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7039,9 +7158,10 @@
             }
         },
         "node_modules/sucrase/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -7060,13 +7180,13 @@
             }
         },
         "node_modules/sucrase/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -7099,19 +7219,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/swr": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.2.tgz",
-            "integrity": "sha512-RosxFpiabojs75IwQ316DGoDRmOqtiAj0tg8wCcbEu4CiLZBs/a9QNtHV7TUfDXmmlgqij/NqzKq/eLelyv9xA==",
-            "license": "MIT",
-            "dependencies": {
-                "dequal": "^2.0.3",
-                "use-sync-external-store": "^1.4.0"
-            },
-            "peerDependencies": {
-                "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/tailwindcss": {
@@ -7192,27 +7299,15 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/throttleit": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-            "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/tinyglobby": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-            "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.3",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -7222,11 +7317,14 @@
             }
         },
         "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.3",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-            "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -7237,9 +7335,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7263,16 +7361,16 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=18.12"
             },
             "peerDependencies": {
-                "typescript": ">=4.2.0"
+                "typescript": ">=4.8.4"
             }
         },
         "node_modules/ts-interface-checker": {
@@ -7486,34 +7584,12 @@
                 "punycode": "^2.1.0"
             }
         },
-        "node_modules/use-sync-external-store": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-            "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -7738,16 +7814,19 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yocto-queue": {
@@ -7761,25 +7840,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/zod": {
-            "version": "3.24.2",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-            "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
-        "node_modules/zod-to-json-schema": {
-            "version": "3.24.3",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.3.tgz",
-            "integrity": "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.24.1"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "@aws-sdk/client-bedrock-runtime": "^3.515.0",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
-        "ai": "^4.1.46",
         "bad-words": "^4.0.0",
         "next": "^15.3.0",
         "next-themes": "^0.2.1",
@@ -25,7 +24,7 @@
         "@types/react-dom": "^18",
         "autoprefixer": "^10.4.20",
         "eslint": "^8",
-        "eslint-config-next": "14.0.4",
+        "eslint-config-next": "^15.5.15",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
         "typescript": "^5"


### PR DESCRIPTION
…e vulnerabilities

- Remove `ai` (Vercel AI SDK) — unused in the codebase; project uses AWS Bedrock directly. Eliminates moderate-severity XSS via jsondiffpatch and file-type whitelist bypass advisories.
- Update eslint-config-next from 14.0.4 → 15.x to pull in a fixed @typescript-eslint/parser, resolving 3 high-severity minimatch ReDoS vulnerabilities.
- Result: 0 vulnerabilities (was 5: 2 moderate, 3 high).