### PR TITLE
feat: add hypergeometric opening hand calculator

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
                 "next": "^15.3.0",
                 "next-themes": "^0.2.1",
                 "react": "^18",
-                "react-dom": "^18"
+                "react-dom": "^18",
+                "recharts": "^3.8.1"
             },
             "devDependencies": {
                 "@types/node": "^20",
@@ -1725,6 +1726,42 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+            "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@reduxjs/toolkit/node_modules/immer": {
+            "version": "11.1.4",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+            "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2377,6 +2414,18 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+            "license": "MIT"
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2385,6 +2434,69 @@
             "dependencies": {
                 "tslib": "^2.8.0"
             }
+        },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "license": "MIT"
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -2407,14 +2519,14 @@
             "version": "15.7.14",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
             "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "18.3.18",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
             "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
@@ -2430,6 +2542,12 @@
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.58.2",
@@ -3404,6 +3522,15 @@
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
             "license": "MIT"
         },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3473,8 +3600,129 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
+        },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
@@ -3554,6 +3802,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -3858,6 +4112,16 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/es-toolkit": {
+            "version": "1.45.1",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+            "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -4329,6 +4593,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -4870,6 +5140,16 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+            "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4929,6 +5209,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/is-array-buffer": {
@@ -6394,8 +6683,30 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/read-cache": {
             "version": "1.0.0",
@@ -6418,6 +6729,51 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            }
+        },
+        "node_modules/recharts": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+            "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+            "license": "MIT",
+            "workspaces": [
+                "www"
+            ],
+            "dependencies": {
+                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^10.1.1",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.1.1",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -6463,6 +6819,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "1.22.10",
@@ -7299,6 +7661,12 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.16",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7584,12 +7952,43 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "license": "MIT AND ISC",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
+            }
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "next": "^15.3.0",
         "next-themes": "^0.2.1",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "recharts": "^3.8.1"
     },
     "devDependencies": {
         "@types/node": "^20",

--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import HandCalculator from '@/components/HandCalculator';
+
+export const metadata = {
+  title: 'Hand Calculator — YugiAI',
+  description: 'Hypergeometric probability calculator for Yu-Gi-Oh! deck building. Analyze starter and brick ratios for optimal opening hands.',
+};
+
+export default function CalculatorPage() {
+  return (
+    <>
+      <div className="self-start w-full flex items-center justify-between mb-6">
+        <Link
+          href="/"
+          className="flex items-center text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          <span className="mr-1">←</span> Back to Home
+        </Link>
+        <Link
+          href="/judge"
+          className="flex items-center text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Ask the Judge <span className="ml-1">→</span>
+        </Link>
+      </div>
+
+      <HandCalculator />
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,6 +67,25 @@ export default function Home() {
             </li>
           </ul>
         </div>
+
+        <div className="bg-white/80 dark:bg-gray-800/80 rounded-lg p-6 shadow-md backdrop-blur-sm">
+          <h2 className="text-2xl font-semibold mb-2">Deck Tools</h2>
+          <p className="text-gray-600 dark:text-gray-400 mb-4 text-sm">
+            Math-backed utilities to sharpen your deck building.
+          </p>
+          <Link
+            href="/calculator"
+            className="flex items-center justify-between rounded-lg px-4 py-3 text-blue-600 dark:text-blue-400 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors border border-gray-200 dark:border-gray-700"
+          >
+            <div>
+              <div className="font-medium">Opening Hand Calculator</div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Hypergeometric odds for starters &amp; bricks
+              </div>
+            </div>
+            <span className="ml-3 shrink-0">→</span>
+          </Link>
+        </div>
       </div>
     </>
   );

--- a/src/components/HandCalculator.tsx
+++ b/src/components/HandCalculator.tsx
@@ -1,0 +1,589 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+  Area,
+  ComposedChart,
+} from "recharts";
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: Array<{ dataKey?: string; value?: number }>;
+  label?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Math helpers
+// ---------------------------------------------------------------------------
+
+function comb(n: number, k: number): number {
+  if (k < 0 || k > n) return 0;
+  if (k === 0 || k === n) return 1;
+  k = Math.min(k, n - k);
+  let result = 1;
+  for (let i = 0; i < k; i++) {
+    result = (result * (n - i)) / (i + 1);
+  }
+  return result;
+}
+
+function hypergeoPAtLeastOne(deckSize: number, copies: number, handSize: number): number {
+  if (copies <= 0) return 0;
+  if (copies >= deckSize) return 1;
+  const pZero = comb(deckSize - copies, handSize) / comb(deckSize, handSize);
+  return Math.max(0, Math.min(1, 1 - pZero));
+}
+
+function hypergeoPZero(deckSize: number, bricks: number, handSize: number): number {
+  if (bricks <= 0) return 1;
+  if (bricks >= deckSize) return 0;
+  return Math.max(0, Math.min(1, comb(deckSize - bricks, handSize) / comb(deckSize, handSize)));
+}
+
+// ---------------------------------------------------------------------------
+// Thresholds
+// ---------------------------------------------------------------------------
+
+const STARTER_THRESHOLD = 85;
+const BRICK_THRESHOLD = 66.2;
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+interface StarterPoint {
+  starters: number;
+  probPct: number;
+  belowProb: number;
+  aboveProb: number | null;
+}
+
+interface BrickPoint {
+  bricks: number;
+  cleanPct: number;
+  safeProb: number | null;
+  dangerProb: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Tooltips
+// ---------------------------------------------------------------------------
+
+function StarterTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const probPct = payload.find((p) => p.dataKey === "probPct")?.value;
+  if (probPct == null) return null;
+  const isGolden = probPct >= STARTER_THRESHOLD;
+
+  return (
+    <div
+      className="rounded-lg px-4 py-3 font-mono text-sm shadow-xl"
+      style={{
+        background: "rgba(15, 15, 26, 0.95)",
+        border: `1px solid ${isGolden ? "#c8a84b" : "#2a2a4a"}`,
+        boxShadow: isGolden ? "0 0 16px rgba(200,168,75,0.3)" : "0 4px 20px rgba(0,0,0,0.4)",
+      }}
+    >
+      <p className="text-[10px] uppercase tracking-widest mb-0.5" style={{ color: "#7070a0" }}>
+        Starters in Deck
+      </p>
+      <p className="text-xl font-bold mb-2 text-slate-100">{label}</p>
+      <p className="text-[10px] uppercase tracking-widest mb-0.5" style={{ color: "#7070a0" }}>
+        Open Rate
+      </p>
+      <p className="text-xl font-bold" style={{ color: isGolden ? "#c8a84b" : "#a0a0d0" }}>
+        {probPct.toFixed(1)}%
+      </p>
+      {isGolden && (
+        <p className="text-[10px] tracking-widest mt-1.5" style={{ color: "#c8a84b" }}>
+          ✦ GOLDEN ZONE
+        </p>
+      )}
+    </div>
+  );
+}
+
+function BrickTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const cleanPct = payload.find((p) => p.dataKey === "cleanPct")?.value;
+  if (cleanPct == null) return null;
+  const isSafe = cleanPct >= BRICK_THRESHOLD;
+
+  return (
+    <div
+      className="rounded-lg px-4 py-3 font-mono text-sm shadow-xl"
+      style={{
+        background: "rgba(15, 15, 26, 0.95)",
+        border: `1px solid ${isSafe ? "#2a2a4a" : "#7a1a1a"}`,
+        boxShadow: isSafe ? "0 4px 20px rgba(0,0,0,0.4)" : "0 0 16px rgba(180,40,40,0.25)",
+      }}
+    >
+      <p className="text-[10px] uppercase tracking-widest mb-0.5" style={{ color: "#7070a0" }}>
+        Bricks in Deck
+      </p>
+      <p className="text-xl font-bold mb-2 text-slate-100">{label}</p>
+      <p className="text-[10px] uppercase tracking-widest mb-0.5" style={{ color: "#7070a0" }}>
+        Clean Hand Odds
+      </p>
+      <p className="text-xl font-bold" style={{ color: isSafe ? "#a0a0d0" : "#e05050" }}>
+        {cleanPct.toFixed(1)}%
+      </p>
+      {!isSafe && (
+        <p className="text-[10px] tracking-widest mt-1.5" style={{ color: "#e05050" }}>
+          ✖ DANGER ZONE
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function HandCalculator() {
+  const [deckSize, setDeckSize] = useState(40);
+  const [goingFirst, setGoingFirst] = useState(true);
+
+  const handSize = goingFirst ? 5 : 6;
+  const maxStarters = Math.min(deckSize, 40);
+  const maxBricks = Math.min(deckSize, 20);
+
+  const starterData: StarterPoint[] = Array.from({ length: maxStarters }, (_, i) => {
+    const starters = i + 1;
+    const probPct = hypergeoPAtLeastOne(deckSize, starters, handSize) * 100;
+    return {
+      starters,
+      probPct,
+      belowProb: probPct < STARTER_THRESHOLD ? probPct : STARTER_THRESHOLD,
+      aboveProb: probPct >= STARTER_THRESHOLD ? probPct : null,
+    };
+  });
+
+  const goldenEntry = starterData.find((d) => d.probPct >= STARTER_THRESHOLD);
+  const goldenStarters = goldenEntry?.starters ?? null;
+
+  const brickData: BrickPoint[] = Array.from({ length: maxBricks }, (_, i) => {
+    const bricks = i + 1;
+    const cleanPct = hypergeoPZero(deckSize, bricks, handSize) * 100;
+    const isSafe = cleanPct >= BRICK_THRESHOLD;
+    return {
+      bricks,
+      cleanPct,
+      safeProb: isSafe ? cleanPct : BRICK_THRESHOLD,
+      dangerProb: !isSafe ? cleanPct : null,
+    };
+  });
+
+  const lastSafeEntry = [...brickData].reverse().find((d) => d.cleanPct >= BRICK_THRESHOLD);
+  const maxSafeBricks = lastSafeEntry?.bricks ?? null;
+
+  const sliderPct = ((deckSize - 40) / 20) * 100;
+
+  return (
+    <div className="w-full max-w-xl font-mono">
+
+      {/* ── Header ── */}
+      <header className="text-center mb-8">
+        <p className="text-[10px] uppercase tracking-[6px] mb-2 opacity-80" style={{ color: "#c8a84b" }}>
+          ✦ Duel Analytics ✦
+        </p>
+        <h1 className="text-3xl sm:text-4xl font-bold uppercase tracking-widest text-gray-900 dark:text-slate-100">
+          Opening Hand Calculator
+        </h1>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400 tracking-wide">
+          Hypergeometric probability — starters &amp; bricks in your opening hand
+        </p>
+      </header>
+
+      {/* ── Parameters ── */}
+      <section className="bg-white/80 dark:bg-gray-800/80 rounded-lg p-6 shadow-md backdrop-blur-sm border border-gray-200 dark:border-gray-700 mb-6">
+        <p className="text-[10px] uppercase tracking-[3px] mb-5 text-gray-400 dark:text-gray-500">
+          Parameters
+        </p>
+
+        {/* Deck size */}
+        <div className="mb-6">
+          <div className="flex justify-between items-baseline mb-2.5">
+            <span className="text-[11px] uppercase tracking-widest text-gray-500 dark:text-gray-400">
+              Deck Size
+            </span>
+            <span className="text-3xl font-bold leading-none" style={{ color: "#c8a84b" }}>
+              {deckSize} cards
+            </span>
+          </div>
+          <input
+            type="range"
+            min={40}
+            max={60}
+            step={1}
+            value={deckSize}
+            onChange={(e) => setDeckSize(Number(e.target.value))}
+            className="w-full h-1 rounded-sm outline-none cursor-pointer appearance-none slider-gold"
+            style={{
+              background: `linear-gradient(to right, #c8a84b ${sliderPct}%, #d1d5db ${sliderPct}%)`,
+            }}
+          />
+          <div className="flex justify-between mt-1.5">
+            <span className="text-[10px] text-gray-400">40</span>
+            <span className="text-[10px] text-gray-400">60</span>
+          </div>
+        </div>
+
+        {/* Turn order */}
+        <div>
+          <p className="text-[11px] uppercase tracking-widest mb-3 text-gray-500 dark:text-gray-400">
+            Turn Order
+          </p>
+          <div className="flex gap-3">
+            {(
+              [
+                { label: "Going First", sub: "5 card hand", value: true },
+                { label: "Going Second", sub: "6 card hand", value: false },
+              ] as const
+            ).map((opt) => {
+              const active = goingFirst === opt.value;
+              return (
+                <button
+                  key={String(opt.value)}
+                  onClick={() => setGoingFirst(opt.value)}
+                  className="flex-1 py-3.5 px-3 rounded-xl cursor-pointer text-center transition-all duration-150"
+                  style={{
+                    background: active
+                      ? "rgba(200,168,75,0.1)"
+                      : "rgba(0,0,0,0.03)",
+                    border: `1px solid ${active ? "#c8a84b" : "rgba(0,0,0,0.1)"}`,
+                    boxShadow: active ? "0 0 12px rgba(200,168,75,0.15)" : "none",
+                  }}
+                >
+                  <div className="flex items-center justify-center gap-2 mb-1">
+                    <div
+                      className="w-3 h-3 rounded-full shrink-0"
+                      style={{
+                        border: `2px solid ${active ? "#c8a84b" : "#9ca3af"}`,
+                        background: active ? "#c8a84b" : "transparent",
+                      }}
+                    />
+                    <span
+                      className="text-xs tracking-wide"
+                      style={{
+                        color: active ? "#c8a84b" : "#6b7280",
+                        fontWeight: active ? 700 : 400,
+                      }}
+                    >
+                      {opt.label}
+                    </span>
+                  </div>
+                  <div
+                    className="text-[10px] tracking-wide"
+                    style={{ color: active ? "#c8a84b" : "#9ca3af" }}
+                  >
+                    {opt.sub}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ════ STARTERS SECTION ════ */}
+
+      <div className="flex items-center gap-3 mb-5">
+        <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+        <span className="text-[10px] uppercase tracking-[4px]" style={{ color: "#c8a84b" }}>
+          ✦ Starters
+        </span>
+        <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 mb-4">
+        {/* Golden Zone card */}
+        <div
+          className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-lg p-5 text-center shadow-md"
+          style={{ border: "1px solid rgba(200,168,75,0.3)" }}
+        >
+          <p className="text-[9px] uppercase tracking-[2px] mb-2.5 text-gray-400">
+            Golden Zone (85%+)
+          </p>
+          {goldenStarters != null ? (
+            <>
+              <div className="text-5xl font-bold leading-none" style={{ color: "#c8a84b" }}>
+                {goldenStarters}
+              </div>
+              <div className="text-[11px] mt-1 text-gray-400">starters needed</div>
+              <div className="text-sm mt-2.5 font-semibold" style={{ color: "#c8a84b" }}>
+                {(hypergeoPAtLeastOne(deckSize, goldenStarters, handSize) * 100).toFixed(1)}% open rate
+              </div>
+            </>
+          ) : (
+            <div className="text-sm mt-4 text-gray-400">Not reachable</div>
+          )}
+        </div>
+
+        {/* Starter reference card */}
+        <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-lg p-5 shadow-md border border-gray-200 dark:border-gray-700">
+          <p className="text-[9px] uppercase tracking-[2px] mb-3 text-gray-400">
+            Starter Reference
+          </p>
+          {[3, 6, 9, 12, 15, 18].filter((c) => c <= deckSize).map((count) => {
+            const pPct = hypergeoPAtLeastOne(deckSize, count, handSize) * 100;
+            const isGolden = pPct >= STARTER_THRESHOLD;
+            return (
+              <div
+                key={count}
+                className="flex justify-between py-1.5 border-b border-gray-100 dark:border-gray-700 last:border-0"
+              >
+                <span className="text-[11px] text-gray-500">{count} starters</span>
+                <span
+                  className="text-[11px]"
+                  style={{
+                    color: isGolden ? "#c8a84b" : "#9ca3af",
+                    fontWeight: isGolden ? 700 : 400,
+                  }}
+                >
+                  {pPct.toFixed(1)}%{isGolden ? " ✦" : ""}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Starters chart */}
+      <section className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-lg pt-6 px-3 pb-4 mb-8 shadow-md border border-gray-200 dark:border-gray-700">
+        <p className="text-[10px] uppercase tracking-[3px] mb-5 pl-2 text-gray-400">
+          Starter Open Rate
+        </p>
+        <ResponsiveContainer width="100%" height={260}>
+          <ComposedChart data={starterData} margin={{ top: 10, right: 16, left: 0, bottom: 24 }}>
+            <defs>
+              <linearGradient id="goldenGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#c8a84b" stopOpacity={0.25} />
+                <stop offset="100%" stopColor="#c8a84b" stopOpacity={0.03} />
+              </linearGradient>
+              <linearGradient id="baseGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#4a3a8a" stopOpacity={0.15} />
+                <stop offset="100%" stopColor="#4a3a8a" stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 6" stroke="rgba(0,0,0,0.06)" vertical={false} />
+            <XAxis
+              dataKey="starters"
+              tick={{ fill: "#9ca3af", fontSize: 11, fontFamily: "'Courier New', monospace" }}
+              tickLine={false}
+              axisLine={{ stroke: "#e5e7eb" }}
+              label={{ value: "Starters in Deck", position: "insideBottom", offset: -12, fill: "#9ca3af", fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            />
+            <YAxis
+              tickFormatter={(v) => `${v}%`}
+              domain={[0, 100]}
+              tick={{ fill: "#9ca3af", fontSize: 11, fontFamily: "'Courier New', monospace" }}
+              tickLine={false}
+              axisLine={false}
+              width={46}
+            />
+            <Tooltip
+              content={<StarterTooltip />}
+              cursor={{ stroke: "rgba(200,168,75,0.2)", strokeWidth: 1, strokeDasharray: "4 4" }}
+            />
+            <Area type="monotone" dataKey="aboveProb" fill="url(#goldenGrad)" stroke="none" connectNulls={false} activeDot={false as never} />
+            <Area type="monotone" dataKey="belowProb" fill="url(#baseGrad)" stroke="none" activeDot={false as never} />
+            <ReferenceLine
+              y={STARTER_THRESHOLD}
+              stroke="#c8a84b"
+              strokeDasharray="6 3"
+              strokeOpacity={0.6}
+              label={{ value: "85% ✦", position: "insideTopRight", fill: "#c8a84b", fontSize: 10, fontFamily: "'Courier New', monospace", opacity: 0.9 }}
+            />
+            <Line
+              type="monotone"
+              dataKey="probPct"
+              stroke="#6a5acd"
+              strokeWidth={2.5}
+              dot={false}
+              activeDot={{ r: 5, fill: "#c8a84b", stroke: "#fff", strokeWidth: 2 }}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+        <div className="flex gap-5 justify-center mt-2">
+          <div className="flex items-center gap-1.5">
+            <div className="w-6 h-0.5" style={{ background: "#6a5acd" }} />
+            <span className="text-[10px] tracking-wide text-gray-400">Open Rate</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="w-4 h-2.5 rounded-sm" style={{ background: "rgba(200,168,75,0.2)", border: "1px solid rgba(200,168,75,0.4)" }} />
+            <span className="text-[10px] tracking-wide text-gray-400">Golden Zone ≥85%</span>
+          </div>
+        </div>
+      </section>
+
+      {/* ════ BRICKS SECTION ════ */}
+
+      <div className="flex items-center gap-3 mb-5">
+        <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+        <span className="text-[10px] uppercase tracking-[4px]" style={{ color: "#e05050" }}>
+          ✖ Bricks
+        </span>
+        <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 mb-4">
+        {/* Safe limit card */}
+        <div
+          className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-lg p-5 text-center shadow-md"
+          style={{ border: "1px solid rgba(180,40,40,0.3)" }}
+        >
+          <p className="text-[9px] uppercase tracking-[2px] mb-2.5 text-gray-400">
+            Max Safe Bricks
+          </p>
+          {maxSafeBricks != null ? (
+            <>
+              <div className="text-5xl font-bold leading-none" style={{ color: "#e05050" }}>
+                {maxSafeBricks}
+              </div>
+              <div className="text-[11px] mt-1 text-gray-400">brick limit</div>
+              <div className="text-sm mt-2.5 font-semibold" style={{ color: "#e05050" }}>
+                {(hypergeoPZero(deckSize, maxSafeBricks, handSize) * 100).toFixed(1)}% clean hands
+              </div>
+              <div className="text-[10px] mt-1.5 text-gray-400">at ≥66.2% threshold</div>
+            </>
+          ) : (
+            <div className="text-sm mt-4 text-gray-400">Exceeds limit</div>
+          )}
+        </div>
+
+        {/* Brick reference card */}
+        <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-lg p-5 shadow-md border border-gray-200 dark:border-gray-700">
+          <p className="text-[9px] uppercase tracking-[2px] mb-3 text-gray-400">
+            Brick Reference
+          </p>
+          {[1, 2, 3, 4, 5, 6, 8, 10].filter((b) => b <= deckSize).map((bricks) => {
+            const cleanPct = hypergeoPZero(deckSize, bricks, handSize) * 100;
+            const isSafe = cleanPct >= BRICK_THRESHOLD;
+            return (
+              <div
+                key={bricks}
+                className="flex justify-between py-1.5 border-b border-gray-100 dark:border-gray-700 last:border-0"
+              >
+                <span className="text-[11px] text-gray-500">{bricks} bricks</span>
+                <span
+                  className="text-[11px]"
+                  style={{
+                    color: isSafe ? "#9ca3af" : "#e05050",
+                    fontWeight: isSafe ? 400 : 700,
+                  }}
+                >
+                  {cleanPct.toFixed(1)}%{!isSafe ? " ✖" : ""}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Bricks chart */}
+      <section className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-lg pt-6 px-3 pb-4 mb-5 shadow-md border border-gray-200 dark:border-gray-700">
+        <p className="text-[10px] uppercase tracking-[3px] mb-5 pl-2 text-gray-400">
+          Clean Hand Probability
+        </p>
+        <ResponsiveContainer width="100%" height={260}>
+          <ComposedChart data={brickData} margin={{ top: 10, right: 16, left: 0, bottom: 24 }}>
+            <defs>
+              <linearGradient id="safeGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#4a3a8a" stopOpacity={0.15} />
+                <stop offset="100%" stopColor="#4a3a8a" stopOpacity={0.02} />
+              </linearGradient>
+              <linearGradient id="dangerGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#b42a2a" stopOpacity={0.3} />
+                <stop offset="100%" stopColor="#b42a2a" stopOpacity={0.05} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 6" stroke="rgba(0,0,0,0.06)" vertical={false} />
+            <XAxis
+              dataKey="bricks"
+              tick={{ fill: "#9ca3af", fontSize: 11, fontFamily: "'Courier New', monospace" }}
+              tickLine={false}
+              axisLine={{ stroke: "#e5e7eb" }}
+              label={{ value: "Bricks in Deck", position: "insideBottom", offset: -12, fill: "#9ca3af", fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            />
+            <YAxis
+              tickFormatter={(v) => `${v}%`}
+              domain={[0, 100]}
+              tick={{ fill: "#9ca3af", fontSize: 11, fontFamily: "'Courier New', monospace" }}
+              tickLine={false}
+              axisLine={false}
+              width={46}
+            />
+            <Tooltip
+              content={<BrickTooltip />}
+              cursor={{ stroke: "rgba(180,40,40,0.2)", strokeWidth: 1, strokeDasharray: "4 4" }}
+            />
+            <Area type="monotone" dataKey="safeProb" fill="url(#safeGrad)" stroke="none" connectNulls={false} activeDot={false as never} />
+            <Area type="monotone" dataKey="dangerProb" fill="url(#dangerGrad)" stroke="none" connectNulls={false} activeDot={false as never} />
+            <ReferenceLine
+              y={BRICK_THRESHOLD}
+              stroke="#e05050"
+              strokeDasharray="6 3"
+              strokeOpacity={0.6}
+              label={{ value: "66.2% ✖", position: "insideTopRight", fill: "#e05050", fontSize: 10, fontFamily: "'Courier New', monospace", opacity: 0.9 }}
+            />
+            <Line
+              type="monotone"
+              dataKey="cleanPct"
+              stroke="#6a5acd"
+              strokeWidth={2.5}
+              dot={false}
+              activeDot={{ r: 5, fill: "#e05050", stroke: "#fff", strokeWidth: 2 }}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+        <div className="flex gap-5 justify-center mt-2">
+          <div className="flex items-center gap-1.5">
+            <div className="w-6 h-0.5" style={{ background: "#6a5acd" }} />
+            <span className="text-[10px] tracking-wide text-gray-400">Clean Hand %</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="w-4 h-2.5 rounded-sm" style={{ background: "rgba(180,40,40,0.25)", border: "1px solid rgba(180,40,40,0.4)" }} />
+            <span className="text-[10px] tracking-wide text-gray-400">Danger Zone &lt;66.2%</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Formula footer */}
+      <p className="text-center text-[10px] tracking-widest text-gray-300 dark:text-gray-600 mt-2">
+        P(clean) = C(N−B, n) / C(N, n) &nbsp;·&nbsp; Hypergeometric Distribution
+      </p>
+
+      <style>{`
+        .slider-gold::-webkit-slider-thumb {
+          -webkit-appearance: none;
+          appearance: none;
+          width: 16px;
+          height: 16px;
+          border-radius: 50%;
+          background: #c8a84b;
+          cursor: pointer;
+          box-shadow: 0 0 8px rgba(200,168,75,0.5);
+          border: 2px solid #fff;
+        }
+        .slider-gold::-moz-range-thumb {
+          width: 16px;
+          height: 16px;
+          border-radius: 50%;
+          background: #c8a84b;
+          cursor: pointer;
+          box-shadow: 0 0 8px rgba(200,168,75,0.5);
+          border: 2px solid #fff;
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `/calculator` route with a new `HandCalculator` component at `src/components/HandCalculator.tsx`
- Computes **starter open rate** and **brick-free hand probability** via the hypergeometric distribution, with deck size (40–60) and going-first/second toggles
- Two interactive Recharts charts: starters chart with golden zone (≥85%) shading, bricks chart with danger zone (<66.2%) shading
- Styled to match existing glassmorphism card language (`bg-white/80 dark:bg-gray-800/80`, `backdrop-blur-sm`, dark-mode aware) while preserving YGO gold/purple accent colors
- Home page gains a "Deck Tools" card section linking to the calculator
- Calculator page has bidirectional nav: `← Back to Home` and `Ask the Judge →`
- Adds `recharts@3.8.1` as a production dependency

## Test plan

- [ ] Visit `/` — confirm "Deck Tools" card appears below Examples and links to `/calculator`
- [ ] Visit `/calculator` — confirm page renders without errors in both light and dark mode
- [ ] Adjust deck size slider (40–60) — confirm both charts and reference cards update reactively
- [ ] Toggle Going First / Going Second — confirm hand size changes (5 vs 6) and charts re-render
- [ ] Hover chart data points — confirm custom tooltips appear with correct label/value
- [ ] Visit `/judge` — confirm no regressions on the existing judge page
- [ ] `npm run build` passes cleanly