### PR TITLE
feat: prompt enrichment pipeline + AnimatedResponse fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ node_modules/
 # IDEs and editors
 .vscode/
 .idea/
+
+# Testing artifacts
+testing-screenshots/

--- a/README.md
+++ b/README.md
@@ -62,12 +62,9 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
 AI_MODEL=us.anthropic.claude-3-7-sonnet-20250219-v1:0
-NEXT_PUBLIC_MAX_DURATION=60
 ```
 
 > **Tip:** The `AI_MODEL` value controls which Bedrock model is used. Claude is the default and recommended option. DeepSeek and Gemini model IDs are also supported.
->
-> **Tip:** `NEXT_PUBLIC_MAX_DURATION` sets the Vercel serverless function timeout in seconds. The Hobby plan hard-caps at 60. You can change this via Vercel's dashboard environment variables without a code deploy.
 
 ### 4. Run the development server
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ No account. No setup. Just rulings.
 ## Features
 
 - **Judge-quality rulings** — powered by Claude via AWS Bedrock, configured with a chain-of-thought system prompt tuned for accuracy and TCG correctness
-- **Confidence scoring** — every ruling includes a confidence percentage so you know how certain the answer is
+- **Grounded rulings** — real card effect text is fetched from YGOPRODeck and injected into every ruling call so the model reasons over ground truth, not recalled training data
 - **Player shorthand understood** — ask about "Ash", "Imperm", "D-Shifter", or any other common nickname; the model knows what you mean
 - **Multi-model support** — runs on Claude (default), DeepSeek, or Gemini via AWS Bedrock; switch models via env var
 - **Instant answers for common questions** — predefined, verified responses for frequently asked rulings (Pendulum Summon, Ash vs Called by the Grave, Solemn Strike, Mirrorjade) skip the model entirely for zero-latency results
@@ -62,9 +62,12 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
 AI_MODEL=us.anthropic.claude-3-7-sonnet-20250219-v1:0
+NEXT_PUBLIC_MAX_DURATION=60
 ```
 
 > **Tip:** The `AI_MODEL` value controls which Bedrock model is used. Claude is the default and recommended option. DeepSeek and Gemini model IDs are also supported.
+>
+> **Tip:** `NEXT_PUBLIC_MAX_DURATION` sets the Vercel serverless function timeout in seconds. The Hobby plan hard-caps at 60. You can change this via Vercel's dashboard environment variables without a code deploy.
 
 ### 4. Run the development server
 

--- a/src/app/api/judge/route.ts
+++ b/src/app/api/judge/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDummyJudgeRuling, getJudgeRuling } from '@/lib/ai';
 import { isProdEnv } from '@/lib/util';
 
-export const maxDuration = Number(process.env.NEXT_PUBLIC_MAX_DURATION ?? 60);
+export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/judge/route.ts
+++ b/src/app/api/judge/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDummyJudgeRuling, getJudgeRuling } from '@/lib/ai';
 import { isProdEnv } from '@/lib/util';
 
+export const maxDuration = Number(process.env.NEXT_PUBLIC_MAX_DURATION ?? 60);
+
 export async function POST(request: NextRequest) {
   try {
     const { query } = await request.json();

--- a/src/components/AnimatedResponse.tsx
+++ b/src/components/AnimatedResponse.tsx
@@ -26,8 +26,9 @@ export default function AnimatedResponse({ response, speed = 400 }: AnimatedResp
 
     const timer = setInterval(() => {
       if (currentIndex < characters.length) {
-        setDisplayText((prev) => prev + characters[currentIndex]);
+        const char = characters[currentIndex];
         currentIndex++;
+        setDisplayText((prev) => prev + char);
       } else {
         clearInterval(timer);
         setIsTyping(false);

--- a/src/components/AnimatedResponse.tsx
+++ b/src/components/AnimatedResponse.tsx
@@ -16,16 +16,16 @@ export default function AnimatedResponse({ response, speed = 400 }: AnimatedResp
     }
     
     const characters = response.split('');
-    
+
     // Calculate interval based on desired character per second rate
     const interval = 1000 / speed;
     let currentIndex = 0;
 
     setIsTyping(true);
-    setDisplayText(characters[currentIndex]); // Start with the first character immediately
+    setDisplayText('');
 
     const timer = setInterval(() => {
-      if (currentIndex < characters.length - 1) { // len - 1 is used so it doesn't print undefined at the end
+      if (currentIndex < characters.length) {
         setDisplayText((prev) => prev + characters[currentIndex]);
         currentIndex++;
       } else {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,6 +1,8 @@
 import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
 import {
   ASH_RESPONSE,
+  CARD_EXTRACTION_MODEL,
+  CARD_EXTRACTION_PROMPT,
   DEFAULT_CLAUDE_MODEL,
   JUDGE_SYSTEM_PROMPT_v1,
   JUDGE_SYSTEM_PROMPT_v1_CHAIN_OF_THOUGHT,
@@ -8,6 +10,7 @@ import {
   PENDULUM_RESPONSE,
   SOLEMN_RESPONSE,
 } from "./constants";
+import { fetchMultipleCardTexts } from "./ygoprodeck";
 import { isClaudeModel, isDeepseekModel, isGeminiModel } from "./util";
 
 export const JUDGE_SYSTEM_PROMPT = JUDGE_SYSTEM_PROMPT_v1_CHAIN_OF_THOUGHT;
@@ -27,7 +30,7 @@ const prepareModelPayload = (modelId: string, systemPrompt: string, query: strin
   if (isClaudeModel()) {
     return JSON.stringify({
       anthropic_version: "bedrock-2023-05-31",
-      max_tokens: 1000,
+      max_tokens: 1500,
       temperature: 0.1, // Add this line to lower output randomness and increase correctness, perfect for /judge
       top_p: 0.9,
       system: systemPrompt,
@@ -97,6 +100,35 @@ const getConstantResponse = (query: string): string => {
   return "";
 };
 
+// Stage 1: Extract canonical card names from the user query via Haiku
+export async function extractCardNames(query: string): Promise<string[]> {
+  try {
+    const payload = JSON.stringify({
+      anthropic_version: "bedrock-2023-05-31",
+      max_tokens: 200,
+      temperature: 0,
+      system: CARD_EXTRACTION_PROMPT,
+      messages: [{ role: "user", content: query }]
+    });
+
+    const command = new InvokeModelCommand({
+      modelId: CARD_EXTRACTION_MODEL,
+      contentType: "application/json",
+      accept: "application/json",
+      body: payload
+    });
+
+    const response = await bedrockClient.send(command);
+    const responseBody = new TextDecoder().decode(response.body);
+    const text = JSON.parse(responseBody).content[0].text.trim();
+    const cardNames = JSON.parse(text);
+    return Array.isArray(cardNames) ? cardNames : [];
+  } catch (error) {
+    console.error("Error extracting card names:", error);
+    return []; // Graceful fallback — ruling call proceeds without injection
+  }
+}
+
 // Get ruling from AI model
 export async function getJudgeRuling(query: string): Promise<string> {
   // Check if the query matches one of the four default
@@ -106,8 +138,19 @@ export async function getJudgeRuling(query: string): Promise<string> {
   }
   // Otherwise, get the ruling from the model
   try {
+    // Stage 1: Extract card names via Haiku
+    const cardNames = await extractCardNames(query);
+
+    // Stage 2: Fetch card text from YGOPRODeck (parallel)
+    const cardContext = await fetchMultipleCardTexts(cardNames);
+
+    // Stage 3: Build augmented system prompt and call Sonnet
     const modelId = process.env.AI_MODEL || DEFAULT_CLAUDE_MODEL;
-    const payload = prepareModelPayload(modelId, JUDGE_SYSTEM_PROMPT, query);
+    const augmentedSystemPrompt = cardContext
+      ? `${JUDGE_SYSTEM_PROMPT}\n\n${cardContext}`
+      : JUDGE_SYSTEM_PROMPT;
+
+    const payload = prepareModelPayload(modelId, augmentedSystemPrompt, query);
 
     const command = new InvokeModelCommand({
       modelId: modelId,
@@ -115,12 +158,12 @@ export async function getJudgeRuling(query: string): Promise<string> {
       accept: "application/json",
       body: payload
     });
-    
+
     const response = await bedrockClient.send(command);
-    
+
     // Convert the UInt8Array to string
     const responseBody = new TextDecoder().decode(response.body);
-    
+
     return extractResponseText(modelId, responseBody);
   } catch (error) {
     console.error("Error getting ruling:", error);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,24 @@
 export const APP_NAME = "YugiAI";
+
+export const CARD_EXTRACTION_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+export const CARD_EXTRACTION_PROMPT = `You are a Yu-Gi-Oh card name extractor.
+Given a ruling query, extract all Yu-Gi-Oh card names mentioned, expanding any shorthand or nicknames to their canonical full names.
+Include anything that appears to be a card name even if unfamiliar to you — do not skip unknown cards.
+
+Common shorthand examples (non-exhaustive):
+- "Ash" = "Ash Blossom & Joyous Spring"
+- "Imperm" = "Infinite Impermanence"
+- "Veiler" = "Effect Veiler"
+- "Nibiru" = "Nibiru, the Primal Being"
+- "D-Shifter" = "Dimension Shifter"
+- "Called By" = "Called by the Grave"
+- "Crossout" = "Crossout Designator"
+- "Droll" = "Droll & Lock Bird"
+
+Return ONLY a valid JSON array of canonical card name strings. No explanation, no markdown, no preamble.
+Example output: ["Infinite Impermanence", "Evilswarm Castor"]
+If no card names are found, return an empty array: []`;
 export const APP_DESCRIPTION = "Instant and accurate Yu-Gi-Oh! TCG rulings assistant";
 export const DEFAULT_CLAUDE_MODEL = "anthropic.claude-3-sonnet-20240229";
 
@@ -100,7 +120,7 @@ RULING PRINCIPLES:
 RESPONSE FORMAT:
 RULING: Begin with a clear, direct 1-3 sentence answer to the ruling question
 EXPLANATION: Explain the core game mechanics determining this ruling. Think step by step and walk through the interaction clearly, especially if it involves timing, chains, or multiple card effects.
-CONFIDENCE: Provide a confidence percentage for how sure you are that this ruling is correct 
+ERRATA NOTE: If the ruling depends on an official errata or ruling that goes beyond what the card text alone states, note this explicitly so the user knows to verify against Yugipedia if needed.
 
 For common misconceptions, be sure to clarify:
 - The difference between negating activations vs negating effects
@@ -109,7 +129,28 @@ For common misconceptions, be sure to clarify:
 - Quick effect timing and trigger windows
 - Continuous effects and their interactions
 
-Explain the ruling as if speaking to a player at a tournament who needs a clear, accurate answer quickly.`;
+Explain the ruling as if speaking to a player at a tournament who needs a clear, accurate answer quickly.
+
+RULING EDGE CASES — OFFICIAL ERRATA (these override naive card text reading):
+
+1. SUCCESSFUL SUMMON IMMUNITY
+   Cards: Evilswarm Castor, Constellar Pollux, Dodger Dragon, Dverg of the Nordic Alfar, Blizzard Princess
+   Rule: If any of these monsters are Normal Summoned successfully WITHOUT a negation effect already active on the field at the moment of summon (e.g. face-up Skill Drain), their granted bonus (extra Normal Summon) applies for the rest of the turn — even if the monster is later destroyed, returned to hand, or has its effects negated by cards like Effect Veiler or Infinite Impermanence.
+   Key point: Impermanence or Veiler applied AFTER a successful summon does NOT retroactively remove the granted bonus. Only negation active AT THE MOMENT OF SUMMON prevents it.
+
+2. MISSING THE TIMING
+   Rule: Optional "When... you can" trigger effects can miss the timing if they are not the last thing to happen in a chain or sequence. If the triggering condition is met but another effect resolves after it in the same chain link, the optional trigger cannot be activated.
+   Does NOT apply to: Mandatory triggers, or effects that say "If... you can" (these cannot miss timing).
+
+3. SEGOC (Simultaneous Effects Going On Chain)
+   Rule: When multiple mandatory trigger effects activate simultaneously, the turn player orders their effects first on the chain, then the opponent orders theirs. The chain then resolves in reverse order (last in, first out).
+
+4. SPELL SPEED AND RESPONSE WINDOWS
+   Rule: Infinite Impermanence and Effect Veiler (Spell Speed 1 for Veiler, Spell Speed 2 for Imperm as a card) can only be activated during the opponent's turn or in response to the opponent's action in the correct phase. Veiler can only be used during the opponent's Main Phase. Imperm as a card can be used during the Battle Phase and other phases.
+   Note: If Imperm is activated in a column where a Spell/Trap the activating player controls exists, its column negation does not apply.
+
+5. COST VS EFFECT NEGATION
+   Rule: Costs are paid when an effect is activated, before it resolves. Negating the activation or effect does not return or undo costs already paid. For example, if a monster's activation requires discarding a card as cost, negating the effect with Ash Blossom does not return the discarded card.`;
 
 export const JUDGE_SYSTEM_PROMPT_v1_JSON = `You are a highly experienced judge at a sanctioned Yu-Gi-Oh! TCG event with comprehensive knowledge of all rulings in both TCG and OCG formats. Always assume queries refer to TCG rulings unless OCG is specifically mentioned.
 

--- a/src/lib/ygoprodeck.ts
+++ b/src/lib/ygoprodeck.ts
@@ -1,0 +1,44 @@
+interface YGOCard {
+  name: string;
+  desc: string;
+  type: string;
+}
+
+interface YGOApiResponse {
+  data: YGOCard[];
+}
+
+export async function fetchCardText(cardName: string): Promise<string | null> {
+  try {
+    const encoded = encodeURIComponent(cardName);
+    // Try exact match first
+    let res = await fetch(`https://db.ygoprodeck.com/api/v7/cardinfo.php?name=${encoded}`);
+
+    // Fall back to fuzzy match if exact fails
+    if (!res.ok) {
+      res = await fetch(`https://db.ygoprodeck.com/api/v7/cardinfo.php?fname=${encoded}`);
+    }
+
+    if (!res.ok) return null;
+
+    const data: YGOApiResponse = await res.json();
+    if (!data.data || data.data.length === 0) return null;
+
+    const card = data.data[0];
+    return `${card.name} (${card.type}): ${card.desc}`;
+  } catch (error) {
+    console.error(`Error fetching card text for "${cardName}":`, error);
+    return null;
+  }
+}
+
+export async function fetchMultipleCardTexts(cardNames: string[]): Promise<string> {
+  if (cardNames.length === 0) return "";
+
+  const results = await Promise.all(cardNames.map(fetchCardText));
+  const found = results.filter((r): r is string => r !== null);
+
+  if (found.length === 0) return "";
+
+  return `CARD DATA (use as ground truth for this ruling):\n${found.map(c => `- ${c}`).join("\n")}`;
+}


### PR DESCRIPTION
## Summary

- Adds a 3-stage ruling pipeline: Haiku extracts card names from shorthand → YGOPRODeck fetches real card effect text → Sonnet ruling call receives injected card data as ground truth, preventing hallucinated or outdated effects
- Replaces the CONFIDENCE response field with ERRATA NOTE (confidence was always 98–100% regardless of accuracy, providing false assurance to users)
- Adds 5 ruling edge cases to the system prompt: successful summon immunity, missing the timing, SEGOC, spell speed windows, cost vs effect negation
- Increases `max_tokens` from 1000 → 1500 to prevent response truncation on complex multi-card rulings
- Exports `maxDuration` on the judge route via `NEXT_PUBLIC_MAX_DURATION` env var so timeout can be changed in Vercel dashboard without a deploy
- Fixes `AnimatedResponse` off-by-one bug that doubled the first character of every response (visual artifact seen as "RRuling" / "uuling")
- Updates README to document new env var and replace confidence scoring feature bullet

## Test plan

- [x] Submit `"imperm vs Evilswarm Castor"` — should correctly rule that the extra Normal Summon is still granted after a successful summon
- [x] Submit `"can ash stop droll"` — verify Haiku expands both shorthands and card text is injected
- [x] Submit a query with an obscure card — verify card text appears in server logs (no ValidationException for Haiku)
- [x] Submit `"how does the damage step work"` (no card names) — verify graceful fallback, no crash
- [x] Submit one of the 4 hardcoded queries (e.g. `"How do I pendulum summon?"`) — verify constant response returned instantly, no model call
- [x] Verify first character of animated response is no longer doubled
- [x] Verify Vercel function does not time out under normal conditions