### PR TITLE
fix: Next.js Image sizes prop + card name extraction log

### DIFF
--- a/src/components/MillenniumBackground.tsx
+++ b/src/components/MillenniumBackground.tsx
@@ -28,10 +28,11 @@ export default function MillenniumBackground() {
   return (
     <div className="fixed inset-0 z-0 flex items-center justify-center opacity-10 dark:opacity-20 pointer-events-none">
       <div className="relative w-64 h-64 md:w-80 md:h-80">
-        <Image 
+        <Image
           src={`/images/millennium-items/${item}.png`}
           alt={`Millennium ${item}`}
           fill
+          sizes="(max-width: 768px) 256px, 320px"
           className="object-contain"
           priority
         />

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -122,7 +122,9 @@ export async function extractCardNames(query: string): Promise<string[]> {
     const responseBody = new TextDecoder().decode(response.body);
     const text = JSON.parse(responseBody).content[0].text.trim();
     const cardNames = JSON.parse(text);
-    return Array.isArray(cardNames) ? cardNames : [];
+    const result = Array.isArray(cardNames) ? cardNames : [];
+    console.log("Extracted card names:", result);
+    return result;
   } catch (error) {
     console.error("Error extracting card names:", error);
     return []; // Graceful fallback — ruling call proceeds without injection


### PR DESCRIPTION
## Summary

- Adds `sizes="(max-width: 768px) 256px, 320px"` to the `MillenniumBackground` fill image, resolving the Next.js console warning and enabling proper srcset generation — values match the Tailwind `w-64`/`md:w-80` container exactly
- Commits the `console.log` for Haiku-extracted card names; it's server-side only (never reaches the browser) so it's fine in prod as a lightweight debugging aid

> Safe to merge: yes