### PR TITLE
fix: DeepSeek R1 null response + Haiku JSON fence stripping

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -44,7 +44,7 @@ const prepareModelPayload = (modelId: string, systemPrompt: string, query: strin
         { role: "system", content: systemPrompt },
         { role: "user", content: query }
       ],
-      max_tokens: 1000,
+      max_tokens: 8000, // R1 burns tokens on chain-of-thought before producing content
       temperature: 0.1 // Lowers output randomness and increase correctness, perfect for /judge
     });
   }
@@ -73,7 +73,8 @@ const extractResponseText = (modelId: string, responseBody: any) => {
     } else if (isGeminiModel()) {
       return JSON.parse(responseBody).candidates[0].content.parts[0].text;
     } else if (isDeepseekModel()) {
-      return JSON.parse(responseBody).choices[0].message.content;
+      const msg = JSON.parse(responseBody).choices[0].message;
+      return msg.content ?? msg.reasoning_content ?? null;
     }
     
     throw new Error(`Unsupported model response format: ${modelId}`);
@@ -120,7 +121,8 @@ export async function extractCardNames(query: string): Promise<string[]> {
 
     const response = await bedrockClient.send(command);
     const responseBody = new TextDecoder().decode(response.body);
-    const text = JSON.parse(responseBody).content[0].text.trim();
+    const raw = JSON.parse(responseBody).content[0].text.trim();
+    const text = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
     const cardNames = JSON.parse(text);
     const result = Array.isArray(cardNames) ? cardNames : [];
     console.log("Extracted card names:", result);
@@ -165,6 +167,7 @@ export async function getJudgeRuling(query: string): Promise<string> {
 
     // Convert the UInt8Array to string
     const responseBody = new TextDecoder().decode(response.body);
+    console.log("Model response (first 300 chars):", responseBody.substring(0, 300));
 
     return extractResponseText(modelId, responseBody);
   } catch (error) {


### PR DESCRIPTION
## Summary

### Bug 1 — Haiku returns markdown-fenced JSON despite prompt instructions

`extractCardNames` sends a prompt explicitly saying _"Return ONLY a valid JSON array … No markdown"_, but Claude Haiku 4.5 still wraps the array in \`\`\`json … \`\`\` fences, crashing `JSON.parse`.

**Before:**
```
Error extracting card names: SyntaxError: Unexpected token '`', "```json\n[""... is not valid JSON
```
**After:**
```
Extracted card names: [ 'Fallen of Albaz', 'Alba-Lenatus the Abyss Dragon' ]
```

**Fix:** strip leading ` ```json ` / ` ``` ` and trailing ` ``` ` from the raw text before parsing.

---

### Bug 2 — DeepSeek R1 exhausts `max_tokens` during reasoning, returns `null` content

`AI_MODEL` is set to the DeepSeek R1 Bedrock inference-profile ARN. R1 generates a long `<think>` chain-of-thought block before its final answer. With `max_tokens: 1000` the model used its entire budget on reasoning, leaving `choices[0].message.content` as JSON `null`.

**Before:** `POST /api/judge` → `{"response": null}` — nothing rendered on the page.

**After:** full ruling text returned to the client.

**Fixes:**
- Raised `max_tokens` for DeepSeek from `1000` → `8000` so reasoning + final answer both fit.
- Added `msg.content ?? msg.reasoning_content ?? null` fallback in `extractResponseText` as a belt-and-suspenders guard.
- Added a 300-char debug log of the raw Bedrock response body to aid future diagnosis.

## Test plan

- [x] Submit a Yu-Gi-Oh ruling query that mentions multiple cards (e.g. the Fallen of Albaz / Alba-Lenatus scenario)
- [x] Confirm server logs show `Extracted card names: [...]` with no `SyntaxError`
- [x] Confirm the ruling response renders on the `/judge` page (not blank)
- [x] Confirm server logs show `Model response (first 300 chars):` with actual JSON content, not an empty or null body