### PR TITLE
chore: add CLAUDE.md, update README, bump to v1.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md — YugiAI
+
+## Project overview
+
+YugiAI is a Next.js 15 (App Router) application that provides AI-powered Yu-Gi-Oh! TCG rulings and deck-building analytics. It has two main features:
+
+- **Judge** (`/judge`) — ask a ruling question, get a judge-quality answer backed by real card text
+- **Opening Hand Calculator** (`/calculator`) — hypergeometric probability charts for starters and bricks
+
+---
+
+## Architecture
+
+### Two-stage ruling pipeline (`src/lib/ai.ts`)
+
+Every ruling query goes through two Bedrock calls before the final response:
+
+1. **Extraction (Haiku)** — `extractCardNames(query)` sends the raw query to `CARD_EXTRACTION_MODEL` (Claude Haiku 4.5) with `CARD_EXTRACTION_PROMPT`. Returns a JSON array of canonical card names. The response may arrive wrapped in markdown fences (` ```json ``` `) even when the prompt forbids it — these are stripped before `JSON.parse`.
+
+2. **Card context fetch** — `fetchMultipleCardTexts(cardNames)` hits the YGOPRODeck API (`https://db.ygoprodeck.com/api/v7/cardinfo.php`) for each card name. Falls back to a fuzzy `fname=` search if exact match fails. Returns a formatted string injected into the main system prompt.
+
+3. **Ruling (main model)** — `getJudgeRuling(query)` calls the model set by `AI_MODEL` with the augmented system prompt and returns the text response.
+
+The four predefined queries (Pendulum Summon, Ash vs Called by, Solemn Strike, Mirrorjade) skip both Bedrock calls entirely and return constant strings from `constants.ts`.
+
+### Dev vs. Prod mode
+
+`ENV=PROD` in `.env.local` routes requests to `getJudgeRuling` (real Bedrock calls).
+`ENV=DEV` routes to `getDummyJudgeRuling` (returns the serialised request payload, no Bedrock call).
+
+Card name extraction runs in both modes — the `extractCardNames` log is visible regardless of `ENV`.
+
+---
+
+## Multi-model support
+
+Model selection is controlled by the `AI_MODEL` environment variable. Detection functions in `src/lib/util.ts` use substring matching on `CURRENT_MODEL` (computed once at module load):
+
+| Model family | ID must contain | Payload format | Response field |
+|---|---|---|---|
+| Claude (Bedrock) | `anthropic.claude` | Claude Messages API | `content[0].text` |
+| DeepSeek R1 | `deepseek` | OpenAI-compatible | `choices[0].message.content` |
+| Gemini | `google.gemini` | Gemini format | `candidates[0].content.parts[0].text` |
+
+**DeepSeek R1 gotcha:** R1 generates a `<think>` reasoning block before its final answer. `max_tokens` must be large (≥ 8000) or the model exhausts the budget during reasoning and returns `content: null`. A `reasoning_content` fallback is in place in `extractResponseText`.
+
+**Important:** `CURRENT_MODEL` is a module-level constant — it reads `process.env.AI_MODEL` once at startup. Changing `AI_MODEL` at runtime requires a server restart.
+
+---
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `AWS_REGION` | Yes | Bedrock region (e.g. `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | Yes | IAM credentials with Bedrock invoke permissions |
+| `AWS_SECRET_ACCESS_KEY` | Yes | IAM credentials |
+| `AI_MODEL` | No | Bedrock model ID or inference profile ARN. Defaults to `anthropic.claude-3-sonnet-20240229` |
+| `ENV` | No | `PROD` for real Bedrock calls, `DEV` for dummy endpoint |
+
+---
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/lib/ai.ts` | Bedrock client, two-stage pipeline, model payload/response helpers |
+| `src/lib/constants.ts` | System prompts (v0–v2 + chain-of-thought variant), card extraction prompt, predefined responses |
+| `src/lib/util.ts` | Input sanitisation, profanity filter, model detection (`isClaudeModel` etc.), env helpers |
+| `src/lib/ygoprodeck.ts` | YGOPRODeck API client (`fetchCardText`, `fetchMultipleCardTexts`) |
+| `src/app/api/judge/route.ts` | POST handler — routes to real or dummy ruling based on `ENV` |
+| `src/components/HandCalculator.tsx` | Hypergeometric calculator UI (Recharts, fully client-side, no API calls) |
+| `src/components/JudgeContent.tsx` | Client component — reads `?q=` param, calls `/api/judge`, renders response |
+
+### System prompt versions
+
+`constants.ts` contains several prompt variants; `JUDGE_SYSTEM_PROMPT` in `ai.ts` selects which one is active:
+
+- `v0` — baseline
+- `v1` — improved structure and PSCT awareness  
+- `v1_CHAIN_OF_THOUGHT` — **currently active** — adds official errata edge cases (Evilswarm Castor, SEGOC, etc.)
+- `v1_JSON` — JSON response format (unused)
+- `v2` — condensed token-efficient version (unused)
+
+---
+
+## Branch and PR workflow
+
+- **Never commit to `main`/`master`.** Always create a feature branch first.
+- Branch naming: `fix/`, `feat/`, `chore/` prefix + kebab-case description.
+- After every `gh pr merge`, post a comment: `Merged by Claude Code — model: **claude-sonnet-4-6** — <date EST>`.
+- UI changes: run `/front-end-checkout` (cloudflared tunnel for visual review) before opening a PR.
+
+---
+
+## Common pitfalls
+
+- **Haiku JSON fences** — Haiku returns ` ```json\n[...]\n``` ` even when prompted not to. Always strip fences before `JSON.parse` in `extractCardNames`.
+- **DeepSeek R1 null content** — see multi-model section above; keep `max_tokens` at 8000+.
+- **`isClaudeModel()` uses module-level constant** — if you add a new model family, update both the detection function in `util.ts` and the payload/response branches in `ai.ts`.
+- **`maxDuration` must be a static literal** in Next.js route handlers — do not use a variable or expression.
+- **Profanity filter** — `YGO_SAFE_TERMS` in `constants.ts` allowlists card names that contain words the filter would otherwise flag (e.g. "Snatch Steal").

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ No account. No setup. Just rulings.
 ## Features
 
 - **Judge-quality rulings** — powered by Claude via AWS Bedrock, configured with a chain-of-thought system prompt tuned for accuracy and TCG correctness
-- **Grounded rulings** — real card effect text is fetched from YGOPRODeck and injected into every ruling call so the model reasons over ground truth, not recalled training data
+- **Grounded rulings** — a two-stage pipeline first extracts card names from your query (Claude Haiku), fetches their official effect text from YGOPRODeck, then injects it into the ruling prompt so the model reasons over ground truth, not recalled training data
+- **Opening Hand Calculator** — hypergeometric probability calculator for deck building; shows starter open rates, brick-avoidance odds, the "Golden Zone" (≥85% open rate) and "Danger Zone" thresholds across 40–60 card decks for going-first and going-second hands
 - **Player shorthand understood** — ask about "Ash", "Imperm", "D-Shifter", or any other common nickname; the model knows what you mean
-- **Multi-model support** — runs on Claude (default), DeepSeek, or Gemini via AWS Bedrock; switch models via env var
+- **Multi-model support** — runs on Claude (default), DeepSeek R1, or Gemini via AWS Bedrock; switch models via a single env var
 - **Instant answers for common questions** — predefined, verified responses for frequently asked rulings (Pendulum Summon, Ash vs Called by the Grave, Solemn Strike, Mirrorjade) skip the model entirely for zero-latency results
 - **Content filtering** — built-in profanity filtering with a YGO-safe terms allowlist (e.g. "Snatch Steal" is not flagged)
 - **Dark / light mode** — theme toggle with system preference detection
@@ -27,7 +28,7 @@ No account. No setup. Just rulings.
 | Language | TypeScript |
 | Styling | Tailwind CSS |
 | AI Provider | AWS Bedrock |
-| AI Models | Anthropic Claude 3.7 Sonnet · DeepSeek · Gemini |
+| AI Models | Anthropic Claude · DeepSeek R1 · Gemini (via AWS Bedrock) |
 | Analytics | Vercel Analytics + Speed Insights |
 
 ---
@@ -106,15 +107,22 @@ For full AWS infrastructure setup — IAM user, Bedrock model access, and deploy
 ```
 src/
 ├── app/
-│   ├── api/          # Next.js API routes (judge endpoint)
-│   ├── judge/        # Judge page
-│   └── page.tsx      # Landing page
-├── components/       # UI components (QueryForm, AnimatedResponse, ThemeToggle, …)
+│   ├── api/judge/        # POST /api/judge — two-stage ruling pipeline
+│   ├── calculator/       # Opening Hand Calculator page
+│   ├── judge/            # Judge ruling page
+│   └── page.tsx          # Landing page
+├── components/
+│   ├── AnimatedResponse  # Streams ruling text character-by-character
+│   ├── HandCalculator    # Hypergeometric probability UI (Recharts, client-only)
+│   ├── JudgeContent      # Reads ?q= param, calls /api/judge, renders response
+│   ├── QueryForm         # Shared ruling input form
+│   └── ThemeToggle       # Dark/light mode switch
 └── lib/
-    ├── ai.ts         # Bedrock client and model invocation logic
-    ├── constants.ts  # System prompts, predefined responses, shared constants
-    ├── util.ts       # Model detection helpers, input sanitisation
-    └── theme.ts      # Theme utilities
+    ├── ai.ts             # Bedrock client, two-stage pipeline, payload/response helpers
+    ├── constants.ts      # System prompts (v0–v2), card extraction prompt, canned responses
+    ├── util.ts           # Model detection, input sanitisation, profanity filter
+    ├── ygoprodeck.ts     # YGOPRODeck API client (card text fetcher)
+    └── theme.ts          # Theme utilities
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yugiai",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "private": true,
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
## Summary

- **CLAUDE.md (new)** — first-time project documentation for Claude Code, covering: two-stage ruling pipeline architecture, multi-model support and gotchas, all environment variables, key file index, system prompt variant guide, branch/PR workflow, and common pitfalls
- **README.md** — adds Opening Hand Calculator to the features list; expands the "Grounded rulings" bullet to describe the Haiku extraction + YGOPRODeck injection pipeline; updates the project structure tree and tech stack table
- **package.json** — version bump `1.1.0` → `1.2.0`

---

## Versioning rationale

The last formal GitHub release is **v1.0.0** (March 2025). Since then, two significant features have shipped:

| Feature | Semver impact |
|---|---|
| **Prompt enrichment** — two-stage RAG pipeline (Haiku card-name extraction → YGOPRODeck fetch → augmented system prompt) | `MINOR` — new capability, no breaking changes |
| **Opening Hand Calculator** — hypergeometric probability tool at `/calculator` with starter/brick charts and Golden Zone thresholds | `MINOR` — new page and route, no breaking changes |

Under strict semver, each independently warrants a `MINOR` bump from 1.0.0. `1.1.0` was never tagged or released (only bumped in-dev), so this PR formalises both additions as **v1.2.0**. No APIs were changed or removed; existing integrations and `.env.local` configs are unaffected.

## Test plan

- [x] `CLAUDE.md` renders correctly on GitHub and covers all major subsystems
- [x] README features list accurately reflects the live app
- [x] `npm run build` succeeds with `"version": "1.2.0"` in `package.json`
- [x] No functional code was changed — existing ruling and calculator behaviour unchanged

> Safe to merge: yes