### PR TITLE
chore: bump version to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yugiai",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "private": true,
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `1.2.0` → `1.2.1` to track the patch release

> Safe to merge: yes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)