### PR TITLE
chore: remove dead constants and rename active prompt to v1_2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,7 @@ Model selection is controlled by the `AI_MODEL` environment variable. Detection 
 
 `constants.ts` contains several prompt variants; `JUDGE_SYSTEM_PROMPT` in `ai.ts` selects which one is active:
 
-- `v0` — baseline
-- `v1` — improved structure and PSCT awareness  
-- `v1_CHAIN_OF_THOUGHT` — **currently active** — adds official errata edge cases (Evilswarm Castor, SEGOC, etc.)
-- `v1_JSON` — JSON response format (unused)
-- `v2` — condensed token-efficient version (unused)
+- `v1_2` — **currently active** — adds official errata edge cases (Evilswarm Castor, SEGOC, etc.)
 
 ---
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -4,8 +4,7 @@ import {
   CARD_EXTRACTION_MODEL,
   CARD_EXTRACTION_PROMPT,
   DEFAULT_CLAUDE_MODEL,
-  JUDGE_SYSTEM_PROMPT_v1,
-  JUDGE_SYSTEM_PROMPT_v1_CHAIN_OF_THOUGHT,
+  JUDGE_SYSTEM_PROMPT_v1_2,
   MIRRORJADE_RESPONSE,
   PENDULUM_RESPONSE,
   SOLEMN_RESPONSE,
@@ -13,7 +12,7 @@ import {
 import { fetchMultipleCardTexts } from "./ygoprodeck";
 import { isClaudeModel, isDeepseekModel, isGeminiModel } from "./util";
 
-export const JUDGE_SYSTEM_PROMPT = JUDGE_SYSTEM_PROMPT_v1_CHAIN_OF_THOUGHT;
+export const JUDGE_SYSTEM_PROMPT = JUDGE_SYSTEM_PROMPT_v1_2;
 
 // Initialize the AWS Bedrock client
 const bedrockClient = new BedrockRuntimeClient({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -37,71 +37,7 @@ export const YGO_SAFE_TERMS: string[] = [
   "snatch"
 ];
 
-// Optimized prompt for performance & correctness, tighten the language to reduce token count while maintaining structure, authority, and clarity.
-export const JUDGE_SYSTEM_PROMPT_v2 = `You are a head judge at a sanctioned Yu-Gi-Oh! TCG event with expert knowledge of TCG and OCG rulings. Default to TCG unless OCG is mentioned.
-
-CARD KNOWLEDGE:
-- Understand all shorthand (e.g., "D-Shifter" = Dimension Shifter, "Ash" = Ash Blossom, "Imperm" = Infinite Impermanence)
-- Know archetypes and mechanics (Fiendsmith, Snake-Eye, Fire King, Sky Striker, Blue Eyes, etc.)
-- Interpret PSCT (Problem-Solving Card Text) accurately
-
-RULING PRINCIPLES:
-- Chain links & resolution order
-- Once per turn/chain limits
-- Costs vs effects
-- Mandatory vs optional effects
-- “When... you can” timing
-- Summon conditions & restrictions
-- Negation vs destruction vs sending to GY
-
-RESPONSE FORMAT (JSON):
-{
-  "ruling": "[1-3 sentence answer]",
-  "explanation": "[Step-by-step breakdown of the ruling, using core mechanics]",
-  "confidence": "[Confidence %]"
-}
-
-CLARIFY COMMON MISCONCEPTIONS:
-- Negating activations vs effects
-- Chain blocking
-- Banished face-down interactions
-- Quick effect timing & trigger windows
-- Continuous effect interactions
-
-Answer as if explaining to a player at a tournament who needs a fast, correct ruling. Be clear and precise.`;
-
-// Prompt that has been engineered for better performance & correctness
-export const JUDGE_SYSTEM_PROMPT_v1 = `You are a highly experienced judge at a sanctioned Yu-Gi-Oh! TCG event with comprehensive knowledge of all rulings in both TCG and OCG formats. Always assume queries refer to TCG rulings unless OCG is specifically mentioned.
-
-CARD KNOWLEDGE:
-- You understand all player shorthand (e.g., "D-Shifter" = Dimension Shifter, "Ash" = Ash Blossom & Joyous Spring, "Imperm" = Infinite Impermanence)
-- You know all archetypes and their mechanics (Tearlaments, Spright, Sky Striker, etc.)
-- You understand PSCT (Problem-Solving Card Text) and its implications for card interactions
-
-RULING PRINCIPLES:
-- Chain links and resolution order
-- Once per turn/chain restrictions
-- Cost vs effect distinctions
-- Mandatory vs optional effects
-- Missing the timing with "When... you can" effects
-- Special summoning conditions and restrictions
-- Negation vs destruction vs send to grave
-
-RESPONSE FORMAT:
-1. RULING: Begin with a clear, direct 1-3 sentence answer to the ruling question
-2. EXPLANATION: Explain the core game mechanics determining this ruling
-3. CONFIDENCE: Provide a confidence percentage for how sure you are that this ruling is correct 
-
-For common misconceptions, be sure to clarify:
-- The difference between negating activations vs negating effects
-- Chain blocking mechanics
-- Face-down banished card interactions
-- Quick effect timing and trigger windows
-- Continuous effects and their interactions
-
-Explain the ruling as if speaking to a player at a tournament who needs a clear, accurate answer quickly.`;
-
-export const JUDGE_SYSTEM_PROMPT_v1_CHAIN_OF_THOUGHT = `You are a highly experienced judge at a sanctioned Yu-Gi-Oh! TCG event with comprehensive knowledge of all rulings in both TCG and OCG formats. Always assume queries refer to TCG rulings unless OCG is specifically mentioned.
+export const JUDGE_SYSTEM_PROMPT_v1_2 = `You are a highly experienced judge at a sanctioned Yu-Gi-Oh! TCG event with comprehensive knowledge of all rulings in both TCG and OCG formats. Always assume queries refer to TCG rulings unless OCG is specifically mentioned.
 
 CARD KNOWLEDGE:
 - You understand all player shorthand (e.g., "D-Shifter" = Dimension Shifter, "Ash" = Ash Blossom & Joyous Spring, "Imperm" = Infinite Impermanence)
@@ -152,50 +88,6 @@ RULING EDGE CASES — OFFICIAL ERRATA (these override naive card text reading):
 5. COST VS EFFECT NEGATION
    Rule: Costs are paid when an effect is activated, before it resolves. Negating the activation or effect does not return or undo costs already paid. For example, if a monster's activation requires discarding a card as cost, negating the effect with Ash Blossom does not return the discarded card.`;
 
-export const JUDGE_SYSTEM_PROMPT_v1_JSON = `You are a highly experienced judge at a sanctioned Yu-Gi-Oh! TCG event with comprehensive knowledge of all rulings in both TCG and OCG formats. Always assume queries refer to TCG rulings unless OCG is specifically mentioned.
-
-CARD KNOWLEDGE:
-- You understand all player shorthand (e.g., "D-Shifter" = Dimension Shifter, "Ash" = Ash Blossom & Joyous Spring, "Imperm" = Infinite Impermanence)
-- You know all archetypes and their mechanics (Tearlaments, Spright, Sky Striker, etc.)
-- You understand PSCT (Problem-Solving Card Text) and its implications for card interactions
-
-RULING PRINCIPLES:
-- Chain links and resolution order
-- Once per turn/chain restrictions
-- Cost vs effect distinctions
-- Mandatory vs optional effects
-- Missing the timing with "When... you can" effects
-- Special summoning conditions and restrictions
-- Negation vs destruction vs send to grave
-
-RESPONSE FORMAT (JSON with 3 keys):
-1. RULING: Begin with a clear, direct 1-3 sentence answer to the ruling question
-2. EXPLANATION: Explain the core game mechanics determining this ruling
-3. CONFIDENCE: Provide a confidence percentage for how sure you are that this ruling is correct 
-
-For common misconceptions, be sure to clarify:
-- The difference between negating activations vs negating effects
-- Chain blocking mechanics
-- Face-down banished card interactions
-- Quick effect timing and trigger windows
-- Continuous effects and their interactions
-
-Explain the ruling as if speaking to a player at a tournament who needs a clear, accurate answer quickly.`
-
-// Unused prompt, but kept for reference
-export const JUDGE_SYSTEM_PROMPT_v0 = `You are a judge at a sanctioned Yu-Gi-Oh! TCG event, with knowledge of all rulings in TCG and OCG. Assume queries are for TCG unless specified otherwise. You understand all shorthand and nicknames used by players.
-
-When answering, follow these guidelines:
-1. Focus on the exact interaction or ruling being asked about
-2. Cite the relevant game mechanics
-3. Be concise and clear in your explanation
-4. Understand player shorthand (e.g., "D-Shifter" for Dimension Shifter, "Ash" for Ash Blossom & Joyous Spring)
-5. Mention any differences between TCG and OCG rulings if relevant
-
-First, provide a brief summary of the ruling (1-3 sentences). Then ask if the user would like a more detailed breakdown.`;
-
-
-
 export const PENDULUM_RESPONSE = `RULING: To Pendulum Summon: 1) Place Pendulum Monsters in both Pendulum Zones (leftmost/rightmost Spell Zones) with scale numbers forming a valid range. 2) During your Main Phase, simultaneously Special Summon any number of monsters from your hand and/or face-up Extra Deck whose levels are BETWEEN the two scales. This can be done once per turn.
 
 EXPLANATION:
@@ -213,12 +105,6 @@ KEY NOTES:
 
 ERRATA NOTE: Some older Pendulum Monsters (e.g., "Odd-Eyes Pendulum Dragon") received text updates to clarify they can be placed in Pendulum Zones. Always check for "Pendulum Effect" headers to confirm.`;
 
-export const PENDULUM_RESPONSE_JSON = {
-  "RULING": "To Pendulum Summon, place Pendulum Monsters in your Pendulum Zones, then once per turn during your Main Phase, you can Pendulum Summon monsters from your hand and/or face-up Extra Deck whose Levels are between your Pendulum Scales.",
-  "EXPLANATION": "First, set up your Pendulum Scales by placing Pendulum Monsters in your leftmost and rightmost Spell & Trap Zones (which become Pendulum Zones). The blue number on each Pendulum Monster represents its Pendulum Scale. During your Main Phase, you can declare a Pendulum Summon to Special Summon any number of monsters from your hand and/or face-up Pendulum Monsters from your Extra Deck whose Levels are between (but not equal to) your Pendulum Scales. For example, with scales of 1 and 8, you can summon monsters with Levels 2 through 7.",
-  "CONFIDENCE": "100%"
-}
-
 export const ASH_RESPONSE = `RULING: Called by the Grave can negate Ash Blossom's effect if activated in direct response to Ash's activation, but only after Ash has already been discarded as cost. Ash's effect will still be negated even though it was already activated.
 
 EXPLANATION:
@@ -235,12 +121,6 @@ KEY POINTS:
 - If Called by is activated preemptively (e.g., earlier in the turn before Ash is used), it would prevent Ash from being activated at all during the negation period.
 
 ERRATA NOTE: This interaction relies on the official ruling that Called by the Grave can negate effects that were already activated but not yet resolved, as long as the targeted monster is in the GY when Called by resolves.`;
-
-export const ASH_RESPONSE_JSON = {
-  "RULING": "If Called by the Grave is chained to Ash Blossom & Joyous Spring, it will negate Ash's effect. However, if Called by the Grave is activated before Ash Blossom is activated, then Ash can still be activated and its effect will resolve normally.",
-  "EXPLANATION": "Called by the Grave negates the effects of the targeted monster with the same name until the end of the next turn. When chained directly to Ash Blossom, Called by targets the Ash in grave (which was sent as cost) and negates its effect when resolving. However, if Called by is activated preemptively (before Ash is activated), then Ash can still be activated later in the turn. This is because Called by only negates effects of monsters that are already in the GY when Called by resolves, not monsters that will be sent to the GY later.",
-  "CONFIDENCE": "100%"
-}
 
 export const SOLEMN_RESPONSE = `RULING: Yes, Solemn Strike can be chained to negate the activation of a monster effect, provided it's activated in direct response to that effect's activation.
 
@@ -262,12 +142,6 @@ CL1: Dark Magician's effect is never applied
 
 KEY NOTE: Strike cannot negate continuous monster effects that don't activate (e.g., Skill Drain's ATK reduction), nor can it negate effects that are already resolving (it must respond to the activation itself).`;
 
-export const SOLEMN_RESPONSE_JSON = {
-  "RULING": "Yes, you can chain Solemn Strike to a monster effect, but only when that monster effect is activated, not when it resolves. Solemn Strike can negate the activation of any monster effect and destroy that monster.",
-  "EXPLANATION": "Solemn Strike specifically states it can negate the 'activation' of a monster effect. This means you must chain it directly to the monster effect when it's initially activated. Solemn Strike works against monster effects activated on the field, in the hand, GY, or while banished. It's important to note that Solemn Strike negates the activation itself (not just the effect), which means the entire effect is treated as if it never happened, and the chain link is removed entirely.",
-  "CONFIDENCE": "100% - This is a fundamental application of Solemn Strike's card text and is consistently ruled this way at all levels of play."
-};
-
 export const MIRRORJADE_RESPONSE = `RULING: Yes, Mirrorjade the Iceblade Dragon's destruction effect will trigger when banished by Traptrix Pudica's effect. The effect activates during the End Phase after Mirrorjade leaves the field.
 
 EXPLANATION: Mirrorjade's effect states: "If this Fusion Summoned card in its owner's control leaves the field: You can activate this effect during the End Phase; destroy all monsters your opponent controls." Since Pudica's effect banishes Mirrorjade (making it leave the field), this meets Mirrorjade's trigger condition. The effect doesn't need to activate immediately when leaving — it creates a delayed trigger that can be activated in the End Phase, even though Mirrorjade is already banished.
@@ -280,8 +154,3 @@ KEY POINTS:
 
 This interaction works even if Mirrorjade was banished face-down, as the trigger only requires leaving the field, not specifically being sent to a particular location face-up.`;
 
-export const MIRRORJADE_RESPONSE_JSON = {
-  "RULING": "Yes, Mirrorjade the Iceblade Dragon's destruction effect will trigger when it is banished by Traptrix Pudica's effect. The effect activates when Mirrorjade leaves the field, which includes being banished.",
-  "EXPLANATION": "Mirrorjade's effect states 'If this Fusion Summoned card you control leaves the field', which is a trigger condition that checks if Mirrorjade is no longer on the field, regardless of where it goes (GY, banished, deck, etc). When Traptrix Pudica banishes Mirrorjade, this condition is satisfied because Mirrorjade has left the field. This is different from effects that specifically require a monster to be sent to the GY. 'Leaves the field' is a broad trigger that includes being banished.",
-  "CONFIDENCE": "100%"
-}


### PR DESCRIPTION
## Summary
- Deletes 4 unused prompt variants (`v0`, `v1`, `v1_JSON`, `v2`) and all `*_JSON` predefined response objects — remnants of a JSON output format that was never wired up
- Renames `JUDGE_SYSTEM_PROMPT_v1_CHAIN_OF_THOUGHT` → `JUDGE_SYSTEM_PROMPT_v1_2` to match the app's `1.2.0` version
- Removes the now-unused `JUDGE_SYSTEM_PROMPT_v1` dead import from `ai.ts`
- Updates `CLAUDE.md` to reflect the single active prompt variant

## Test plan
- [ ] Verify `/judge` route still returns rulings (no broken imports)
- [ ] Confirm `JUDGE_SYSTEM_PROMPT` still resolves to the chain-of-thought/errata prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)