### PR TITLE
feat: streaming ruling pipeline with SSE stage indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ node_modules/
 .vscode/
 .idea/
 
+# TypeScript build cache
+tsconfig.tsbuildinfo
+
 # Testing artifacts
 testing-screenshots/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yugiai",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/app/api/judge-stream/route.ts
+++ b/src/app/api/judge-stream/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from 'next/server';
+import { streamJudgeRuling } from '@/lib/ai';
+
+export const maxDuration = 120;
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null);
+  const query: unknown = body?.query;
+
+  if (typeof query !== 'string' || !query) {
+    return new Response(JSON.stringify({ error: 'Invalid query parameter' }), { status: 400 });
+  }
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const event of streamJudgeRuling(query)) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+        }
+      } catch (error) {
+        console.error('Streaming error:', error);
+        const errorEvent = { type: 'error', message: 'Streaming failed' };
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(errorEvent)}\n\n`));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}

--- a/src/app/api/judge-stream/route.ts
+++ b/src/app/api/judge-stream/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { streamJudgeRuling } from '@/lib/ai';
 
-export const maxDuration = 120;
+export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null);

--- a/src/components/JudgeContent.tsx
+++ b/src/components/JudgeContent.tsx
@@ -1,56 +1,120 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import QueryForm from '@/components/QueryForm';
 import AnimatedResponse from '@/components/AnimatedResponse';
+import StageIndicator, { Stage } from '@/components/StageIndicator';
 
 export default function JudgeContent() {
   const searchParams = useSearchParams();
   const [query, setQuery] = useState('');
-  const [response, setResponse] = useState('');
+  const [cannedResponse, setCannedResponse] = useState('');
+  const [streamingText, setStreamingText] = useState('');
+  const [stages, setStages] = useState<Stage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     const queryParam = searchParams.get('q');
-    if (queryParam) {
-      setQuery(queryParam);
-      fetchRuling(queryParam);
-    }
+    if (!queryParam) return;
+    setQuery(queryParam);
+    const controller = new AbortController();
+    fetchStreamingRuling(queryParam, controller.signal);
+    return () => controller.abort();
   }, [searchParams]);
 
-  const fetchRuling = async (queryText: string) => {
+  const fetchStreamingRuling = async (queryText: string, signal?: AbortSignal) => {
+    // Cancel any in-flight request before starting a new one
+    abortRef.current?.abort();
+    const controller = signal ? null : new AbortController();
+    if (controller) abortRef.current = controller;
+    const effectiveSignal = signal ?? controller!.signal;
+
     setIsLoading(true);
-    
+    setCannedResponse('');
+    setStreamingText('');
+    setStages([]);
+
     try {
-      const res = await fetch('/api/judge', {
+      const res = await fetch('/api/judge-stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ query: queryText }),
+        signal: effectiveSignal,
       });
 
-      if (!res.ok) throw new Error('Failed to fetch ruling');
+      if (!res.ok || !res.body) throw new Error('Failed to fetch ruling');
 
-      const data = await res.json();
-      setResponse(data.response);
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let hasStages = false;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const messages = buffer.split('\n\n');
+        buffer = messages.pop() ?? '';
+
+        for (const message of messages) {
+          if (!message.startsWith('data: ')) continue;
+          try {
+            const event = JSON.parse(message.slice(6));
+
+            if (event.type === 'stage') {
+              hasStages = true;
+              setIsLoading(false);
+              setStages((prev) => {
+                const updated = prev.map((s) =>
+                  s.status === 'active' ? { ...s, status: 'complete' as const } : s
+                );
+                return [...updated, { id: event.stage, message: event.message, status: 'active' as const }];
+              });
+            } else if (event.type === 'token') {
+              setIsLoading(false);
+              if (!hasStages) {
+                setCannedResponse(event.content);
+              } else {
+                setStreamingText((prev) => prev + event.content);
+              }
+            } else if (event.type === 'complete') {
+              setIsLoading(false);
+              setStages((prev) =>
+                prev.map((s) => s.status === 'active' ? { ...s, status: 'complete' as const } : s)
+              );
+            } else if (event.type === 'error') {
+              setIsLoading(false);
+              if (hasStages) {
+                setStreamingText(event.message);
+              } else {
+                setCannedResponse(event.message);
+              }
+            }
+          } catch {
+            // Skip malformed SSE event
+          }
+        }
+      }
     } catch (error) {
-      console.error("Error:", error);
-      setResponse("Sorry, there was an error processing your request.");
-    } finally {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
+      console.error('Error:', error);
+      setCannedResponse('Sorry, there was an error processing your request.');
       setIsLoading(false);
     }
   };
 
   const handleSubmit = async (queryText: string) => {
     setQuery(queryText);
-    
-    // Update URL without page reload
     const url = new URL(window.location.href);
     url.searchParams.set('q', queryText);
     window.history.pushState({}, '', url);
-    
-    await fetchRuling(queryText);
+    await fetchStreamingRuling(queryText, undefined);
   };
+
+  const hasResponse = Boolean(cannedResponse || streamingText || stages.length > 0);
 
   return (
     <div className="w-full max-w-2xl mb-8">
@@ -58,9 +122,8 @@ export default function JudgeContent() {
         <h2 className="text-2xl font-semibold mb-4">Ask the Judge</h2>
         <QueryForm onSubmit={handleSubmit} isLoading={isLoading} initialQuery={query} />
       </div>
-      {/* Add spacing between boxes */}
-      {(isLoading || response) && <div className="h-8"></div>}
-      {(isLoading || response) && (
+      {(isLoading || hasResponse) && <div className="h-8"></div>}
+      {(isLoading || hasResponse) && (
         <div className="w-full max-w-2xl">
           {isLoading ? (
             <div className="bg-white/80 dark:bg-gray-800/80 rounded-lg p-6 shadow-md backdrop-blur-sm animate-pulse">
@@ -68,8 +131,21 @@ export default function JudgeContent() {
               <div className="h-4 bg-gray-300 dark:bg-gray-700 rounded w-1/2 mb-2"></div>
               <div className="h-4 bg-gray-300 dark:bg-gray-700 rounded w-5/6"></div>
             </div>
+          ) : cannedResponse ? (
+            <AnimatedResponse response={cannedResponse} />
           ) : (
-            <AnimatedResponse response={response} />
+            <div className="bg-white/80 dark:bg-gray-800/80 rounded-lg p-6 shadow-md backdrop-blur-sm">
+              {stages.length > 0 && (
+                <div className={streamingText ? 'mb-4 pb-4 border-b border-gray-200 dark:border-gray-700' : ''}>
+                  <StageIndicator stages={stages} />
+                </div>
+              )}
+              {streamingText && (
+                <p className="whitespace-pre-wrap text-gray-900 dark:text-gray-100">
+                  {streamingText.trimStart()}
+                </p>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/src/components/StageIndicator.tsx
+++ b/src/components/StageIndicator.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+export interface Stage {
+  id: string;
+  message: string;
+  status: 'active' | 'complete';
+}
+
+interface StageIndicatorProps {
+  stages: Stage[];
+}
+
+export default function StageIndicator({ stages }: StageIndicatorProps) {
+  return (
+    <div className="space-y-1.5">
+      {stages.map((stage) => (
+        <div
+          key={stage.id}
+          className={`flex items-center gap-2 text-sm transition-colors duration-300 ${
+            stage.status === 'complete'
+              ? 'text-gray-400 dark:text-gray-500'
+              : 'text-gray-800 dark:text-gray-200'
+          }`}
+        >
+          {stage.status === 'complete' ? (
+            <span className="text-green-500 dark:text-green-400 w-3 shrink-0">✓</span>
+          ) : (
+            <span className="inline-block w-2 h-2 rounded-full bg-yellow-500 dark:bg-yellow-400 animate-pulse shrink-0 ml-0.5" />
+          )}
+          <span>{stage.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,4 +1,4 @@
-import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { BedrockRuntimeClient, InvokeModelCommand, InvokeModelWithResponseStreamCommand } from "@aws-sdk/client-bedrock-runtime";
 import {
   ASH_RESPONSE,
   CARD_EXTRACTION_MODEL,
@@ -174,6 +174,112 @@ export async function getJudgeRuling(query: string): Promise<string> {
     return "Sorry, I couldn't process your request. Please try again.";
   }
 
+}
+
+export type StreamEvent =
+  | { type: 'stage'; stage: string; message: string }
+  | { type: 'token'; content: string }
+  | { type: 'complete' }
+  | { type: 'error'; message: string };
+
+export async function* streamJudgeRuling(query: string): AsyncGenerator<StreamEvent> {
+  const constantResponse = getConstantResponse(query);
+  if (constantResponse) {
+    yield { type: 'token', content: constantResponse };
+    yield { type: 'complete' };
+    return;
+  }
+
+  try {
+    yield { type: 'stage', stage: 'parse_query', message: 'Understanding question...' };
+
+    const cardNames = await extractCardNames(query);
+    const cardMsg = cardNames.length > 0
+      ? `Detected ${cardNames.length} card${cardNames.length !== 1 ? 's' : ''}...`
+      : 'Parsing card context...';
+    yield { type: 'stage', stage: 'extract_cards', message: cardMsg };
+
+    const cardContext = await fetchMultipleCardTexts(cardNames);
+    yield { type: 'stage', stage: 'fetch_cards', message: 'Fetching official card text...' };
+
+    const modelId = process.env.AI_MODEL || DEFAULT_CLAUDE_MODEL;
+    const augmentedSystemPrompt = cardContext
+      ? `${JUDGE_SYSTEM_PROMPT}\n\n${cardContext}`
+      : JUDGE_SYSTEM_PROMPT;
+
+    const payload = prepareModelPayload(modelId, augmentedSystemPrompt, query);
+
+    const command = new InvokeModelWithResponseStreamCommand({
+      modelId,
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: payload,
+    });
+
+    yield { type: 'stage', stage: 'reasoning', message: 'Applying PSCT logic...' };
+
+    const streamResponse = await bedrockClient.send(command);
+
+    // Always show generate stage before tokens start arriving
+    yield { type: 'stage', stage: 'generate', message: 'Generating ruling...' };
+
+    // For DeepSeek R1: suppress tokens while inside the hidden <think> block
+    let inThinkBlock = isDeepseekModel();
+    let thinkBuffer = '';
+    let firstChunk = true;
+
+    for await (const event of streamResponse.body!) {
+      if (!('chunk' in event) || !event.chunk?.bytes) continue;
+
+      const chunkText = new TextDecoder().decode(event.chunk.bytes);
+      let token: string | null = null;
+
+      try {
+        const parsed = JSON.parse(chunkText);
+        if (firstChunk) {
+          console.log('[judge-stream] first chunk:', JSON.stringify(parsed).slice(0, 200));
+          firstChunk = false;
+        }
+        if (isClaudeModel()) {
+          if (parsed.type === 'content_block_delta' && parsed.delta?.type === 'text_delta') {
+            token = parsed.delta.text;
+          }
+        } else if (isDeepseekModel()) {
+          // Try streaming delta format first, fall back to full message format
+          const choice = parsed.choices?.[0];
+          token = choice?.delta?.content ?? choice?.message?.content ?? null;
+        }
+      } catch {
+        continue;
+      }
+
+      if (token === null || token === '') continue;
+
+      if (!inThinkBlock) {
+        yield { type: 'token', content: token };
+      } else {
+        // Buffer until </think> tag is fully received
+        thinkBuffer += token;
+        const closeIdx = thinkBuffer.indexOf('</think>');
+        if (closeIdx !== -1) {
+          inThinkBlock = false;
+          const remaining = thinkBuffer.substring(closeIdx + '</think>'.length).replace(/^\n+/, '');
+          if (remaining) yield { type: 'token', content: remaining };
+          thinkBuffer = '';
+        } else if (thinkBuffer.length > 50 && !thinkBuffer.startsWith('<think>')) {
+          // No think block present — emit buffered content directly
+          inThinkBlock = false;
+          yield { type: 'token', content: thinkBuffer };
+          thinkBuffer = '';
+        }
+      }
+    }
+
+    yield { type: 'complete' };
+  } catch (error) {
+    console.error('Error in streamJudgeRuling:', error);
+    yield { type: 'error', message: 'Failed to process your request. Please try again.' };
+  }
 }
 
 // Dummy endpoint, just dumps the request or returns a constant response


### PR DESCRIPTION
## Summary

- Adds `/api/judge-stream` SSE endpoint that emits pipeline milestones in real time instead of blocking until the full ruling is ready
- Users see five stages animate progressively — Understanding question → Detecting cards → Fetching card text → Applying PSCT logic → Generating ruling — with a pulsing dot for the active stage and a checkmark on completion
- DeepSeek R1 `<think>` block tokens are buffered and suppressed; the Generating ruling stage fires immediately so the UI is never stuck waiting for `</think>`
- Canned responses (the four predefined queries) skip stages entirely and use the existing `AnimatedResponse` typewriter effect
- `AbortController` wired to `useEffect` cleanup prevents React Strict Mode double-fire from producing duplicate stage entries
- New `StageIndicator` component handles stage rendering; original `/api/judge` endpoint untouched
- Bumps version `1.2.1 → 1.3.0` (visible UX feature warrants minor bump)
- Adds `tsconfig.tsbuildinfo` to `.gitignore`

## Test plan

- [x] Submit a real ruling query (e.g. "Can Ash Blossom negate Pot of Greed?") and confirm all five stages appear and animate in sequence, followed by streaming ruling text
- [x] Confirm no duplicate stages appear in dev mode (Strict Mode double-fire)
- [x] Submit one of the four canned queries (e.g. "How do I pendulum summon?") and confirm no stages appear — only the typewriter AnimatedResponse
- [x] Submit a second query while one is in flight and confirm the previous request is cancelled cleanly
- [x] Check light and dark mode for stage indicator styling
- [x] Verify ruling text has no leading blank line