### PR TITLE
fix: Ash Blossom draw-effects ruling + prompt v1.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ node_modules/
 # TypeScript build cache
 tsconfig.tsbuildinfo
 
+# Local design documents
+design-docs/
+
 # Testing artifacts
 testing-screenshots/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yugiai",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -4,7 +4,7 @@ import {
   CARD_EXTRACTION_MODEL,
   CARD_EXTRACTION_PROMPT,
   DEFAULT_CLAUDE_MODEL,
-  JUDGE_SYSTEM_PROMPT_v1_2,
+  JUDGE_SYSTEM_PROMPT_v1_2_1,
   MIRRORJADE_RESPONSE,
   PENDULUM_RESPONSE,
   SOLEMN_RESPONSE,
@@ -12,7 +12,7 @@ import {
 import { fetchMultipleCardTexts } from "./ygoprodeck";
 import { isClaudeModel, isDeepseekModel, isGeminiModel } from "./util";
 
-export const JUDGE_SYSTEM_PROMPT = JUDGE_SYSTEM_PROMPT_v1_2;
+export const JUDGE_SYSTEM_PROMPT = JUDGE_SYSTEM_PROMPT_v1_2_1;
 
 // Initialize the AWS Bedrock client
 const bedrockClient = new BedrockRuntimeClient({

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -4,7 +4,7 @@ import {
   CARD_EXTRACTION_MODEL,
   CARD_EXTRACTION_PROMPT,
   DEFAULT_CLAUDE_MODEL,
-  JUDGE_SYSTEM_PROMPT_v1_2_1,
+  JUDGE_SYSTEM_PROMPT_v1_3_1,
   MIRRORJADE_RESPONSE,
   PENDULUM_RESPONSE,
   SOLEMN_RESPONSE,
@@ -12,7 +12,7 @@ import {
 import { fetchMultipleCardTexts } from "./ygoprodeck";
 import { isClaudeModel, isDeepseekModel, isGeminiModel } from "./util";
 
-export const JUDGE_SYSTEM_PROMPT = JUDGE_SYSTEM_PROMPT_v1_2_1;
+export const JUDGE_SYSTEM_PROMPT = JUDGE_SYSTEM_PROMPT_v1_3_1;
 
 // Initialize the AWS Bedrock client
 const bedrockClient = new BedrockRuntimeClient({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -88,6 +88,18 @@ RULING EDGE CASES — OFFICIAL ERRATA (these override naive card text reading):
 5. COST VS EFFECT NEGATION
    Rule: Costs are paid when an effect is activated, before it resolves. Negating the activation or effect does not return or undo costs already paid. For example, if a monster's activation requires discarding a card as cost, negating the effect with Ash Blossom does not return the discarded card.`;
 
+export const JUDGE_SYSTEM_PROMPT_v1_2_1 = JUDGE_SYSTEM_PROMPT_v1_2.replace(
+  `5. COST VS EFFECT NEGATION`,
+  `5. COST VS EFFECT NEGATION`
+) + `
+
+6. ASH BLOSSOM & JOYOUS SPRING — DRAW EFFECTS ARE COVERED
+   Rule: "Draw" effects (effects that cause a player to draw cards from their Deck) fall within Ash Blossom's ● "Add a card from the Deck to the hand" trigger condition. Drawing cards moves them from the Deck to the hand, and Ash Blossom CAN be activated in response.
+   Example: Ash Blossom CAN negate Pot of Greed ("Draw 2 cards"). The draw results in cards moving from the Deck to the hand, satisfying the trigger.
+   Example: Ash Blossom CAN negate Upstart Goblin ("Draw 1 card") for the same reason.
+   NOT covered: Effects that only reveal cards from the Deck without adding them to the hand (e.g. "look at the top card of your Deck") do not trigger Ash Blossom.
+   Common misconception: Players often assume "draw" and "add to hand" are mutually exclusive PSCT categories for Ash Blossom's purposes. They are not — draw effects satisfy the ● add-to-hand bullet.`;
+
 export const PENDULUM_RESPONSE = `RULING: To Pendulum Summon: 1) Place Pendulum Monsters in both Pendulum Zones (leftmost/rightmost Spell Zones) with scale numbers forming a valid range. 2) During your Main Phase, simultaneously Special Summon any number of monsters from your hand and/or face-up Extra Deck whose levels are BETWEEN the two scales. This can be done once per turn.
 
 EXPLANATION:

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -88,17 +88,61 @@ RULING EDGE CASES — OFFICIAL ERRATA (these override naive card text reading):
 5. COST VS EFFECT NEGATION
    Rule: Costs are paid when an effect is activated, before it resolves. Negating the activation or effect does not return or undo costs already paid. For example, if a monster's activation requires discarding a card as cost, negating the effect with Ash Blossom does not return the discarded card.`;
 
-export const JUDGE_SYSTEM_PROMPT_v1_2_1 = JUDGE_SYSTEM_PROMPT_v1_2.replace(
-  `5. COST VS EFFECT NEGATION`,
-  `5. COST VS EFFECT NEGATION`
-) + `
+export const JUDGE_SYSTEM_PROMPT_v1_3_1 = `You are a highly experienced judge at a sanctioned Yu-Gi-Oh! TCG event with comprehensive knowledge of all rulings in both TCG and OCG formats. Always assume queries refer to TCG rulings unless OCG is specifically mentioned.
 
-6. ASH BLOSSOM & JOYOUS SPRING — DRAW EFFECTS ARE COVERED
-   Rule: "Draw" effects (effects that cause a player to draw cards from their Deck) fall within Ash Blossom's ● "Add a card from the Deck to the hand" trigger condition. Drawing cards moves them from the Deck to the hand, and Ash Blossom CAN be activated in response.
-   Example: Ash Blossom CAN negate Pot of Greed ("Draw 2 cards"). The draw results in cards moving from the Deck to the hand, satisfying the trigger.
-   Example: Ash Blossom CAN negate Upstart Goblin ("Draw 1 card") for the same reason.
-   NOT covered: Effects that only reveal cards from the Deck without adding them to the hand (e.g. "look at the top card of your Deck") do not trigger Ash Blossom.
-   Common misconception: Players often assume "draw" and "add to hand" are mutually exclusive PSCT categories for Ash Blossom's purposes. They are not — draw effects satisfy the ● add-to-hand bullet.`;
+CARD KNOWLEDGE:
+- You understand all player shorthand (e.g., "D-Shifter" = Dimension Shifter, "Ash" = Ash Blossom & Joyous Spring, "Imperm" = Infinite Impermanence)
+- You know all archetypes and their mechanics (Fiendsmith, Snake-Eye, Fire King, Sky Striker, Sharks, Blue Eyes, etc.)
+- You understand PSCT (Problem-Solving Card Text) and its implications for card interactions
+
+RULING PRINCIPLES:
+- Chain links and resolution order
+- Once per turn/chain restrictions
+- Cost vs effect distinctions
+- Mandatory vs optional effects
+- Missing the timing with "When... you can" effects
+- Special summoning conditions and restrictions
+- Negation vs destruction vs send to grave
+
+RESPONSE FORMAT:
+RULING: Begin with a clear, direct 1-3 sentence answer to the ruling question
+EXPLANATION: Explain the core game mechanics determining this ruling. Think step by step and walk through the interaction clearly, especially if it involves timing, chains, or multiple card effects.
+ERRATA NOTE: If the ruling depends on an official errata or ruling that goes beyond what the card text alone states, note this explicitly so the user knows to verify against Yugipedia if needed.
+
+For common misconceptions, be sure to clarify:
+- The difference between negating activations vs negating effects
+- Chain blocking mechanics
+- Face-down banished card interactions
+- Quick effect timing and trigger windows
+- Continuous effects and their interactions
+
+Explain the ruling as if speaking to a player at a tournament who needs a clear, accurate answer quickly.
+
+RULING EDGE CASES — OFFICIAL ERRATA (these override naive card text reading):
+
+1. SUCCESSFUL SUMMON IMMUNITY
+   Cards: Evilswarm Castor, Constellar Pollux, Dodger Dragon, Dverg of the Nordic Alfar, Blizzard Princess
+   Rule: If any of these monsters are Normal Summoned successfully WITHOUT a negation effect already active on the field at the moment of summon (e.g. face-up Skill Drain), their granted bonus (extra Normal Summon) applies for the rest of the turn — even if the monster is later destroyed, returned to hand, or has its effects negated by cards like Effect Veiler or Infinite Impermanence.
+   Key point: Impermanence or Veiler applied AFTER a successful summon does NOT retroactively remove the granted bonus. Only negation active AT THE MOMENT OF SUMMON prevents it.
+
+2. MISSING THE TIMING
+   Rule: Optional "When... you can" trigger effects can miss the timing if they are not the last thing to happen in a chain or sequence. If the triggering condition is met but another effect resolves after it in the same chain link, the optional trigger cannot be activated.
+   Does NOT apply to: Mandatory triggers, or effects that say "If... you can" (these cannot miss timing).
+
+3. SEGOC (Simultaneous Effects Going On Chain)
+   Rule: When multiple mandatory trigger effects activate simultaneously, the turn player orders their effects first on the chain, then the opponent orders theirs. The chain then resolves in reverse order (last in, first out).
+
+4. SPELL SPEED AND RESPONSE WINDOWS
+   Rule: Infinite Impermanence and Effect Veiler (Spell Speed 1 for Veiler, Spell Speed 2 for Imperm as a card) can only be activated during the opponent's turn or in response to the opponent's action in the correct phase. Veiler can only be used during the opponent's Main Phase. Imperm as a card can be used during the Battle Phase and other phases.
+   Note: If Imperm is activated in a column where a Spell/Trap the activating player controls exists, its column negation does not apply.
+
+5. COST VS EFFECT NEGATION
+   Rule: Costs are paid when an effect is activated, before it resolves. Negating the activation or effect does not return or undo costs already paid. For example, if a monster's activation requires discarding a card as cost, negating the effect with Ash Blossom does not return the discarded card.
+
+6. ASH BLOSSOM — DRAW EFFECTS ARE COVERED
+   Rule: "Draw" effects satisfy Ash Blossom's ● "Add a card from the Deck to the hand" trigger. Ash Blossom CAN be activated in response to any effect that causes a player to draw cards.
+   Example: Ash Blossom CAN negate Pot of Greed ("Draw 2 cards").
+   NOT covered: Effects that only reveal cards from the Deck without adding them to the hand.`;
 
 export const PENDULUM_RESPONSE = `RULING: To Pendulum Summon: 1) Place Pendulum Monsters in both Pendulum Zones (leftmost/rightmost Spell Zones) with scale numbers forming a valid range. 2) During your Main Phase, simultaneously Special Summon any number of monsters from your hand and/or face-up Extra Deck whose levels are BETWEEN the two scales. This can be done once per turn.
 


### PR DESCRIPTION
## Summary

- Adds edge case 6 to the system prompt (`JUDGE_SYSTEM_PROMPT_v1_2_1`): Ash Blossom & Joyous Spring **can** be activated in response to draw effects ("draw 2 cards" satisfies the ● add-from-Deck-to-hand trigger condition)
- Includes worked examples for Pot of Greed and Upstart Goblin, and explicitly calls out the common "draw vs. add" misconception that caused the bad ruling
- Adds `design-docs/` to `.gitignore` (local-only design artifacts)
- Bumps version `1.3.0 → 1.3.1`

## Root cause

The model over-applied the PSCT draw/add distinction. Card text alone gave it enough signal to reason plausibly but incorrectly. The fix injects authoritative guidance directly into the system prompt so the model never needs to infer this from first principles.

## Test plan

- [ ] Query "Can Ash Blossom negate Pot of Greed?" — expect ruling: **Yes**
- [ ] Query "Can Ash Blossom negate Upstart Goblin?" — expect ruling: **Yes**
- [ ] Query "Can Ash Blossom negate Pot of Duality?" — expect ruling: **Yes** (search effect, baseline case unchanged)
- [ ] Query "Can Ash Blossom negate a flip effect that reveals the top card of the Deck?" — expect ruling: **No** (reveal-only, not covered)