### PR TITLE
feat: render **bold** markdown in ruling responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yugiai",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/components/AnimatedResponse.tsx
+++ b/src/components/AnimatedResponse.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { renderWithBold } from '@/lib/renderWithBold';
 
 interface AnimatedResponseProps {
   response: string;
@@ -41,7 +42,7 @@ export default function AnimatedResponse({ response, speed = 800 }: AnimatedResp
   return (
     <div className="relative">
       <div className="bg-white/80 dark:bg-gray-800/80 rounded-lg p-4 shadow-md backdrop-blur-sm text-gray-900 dark:text-gray-100 animate-fadeIn">
-        <p className="whitespace-pre-wrap">{displayText}</p>
+        <p className="whitespace-pre-wrap">{renderWithBold(displayText)}</p>
         {isTyping && (
           <span className="inline-block w-2 h-4 ml-1 bg-gray-900 dark:bg-gray-100 animate-blink" />
         )}

--- a/src/components/JudgeContent.tsx
+++ b/src/components/JudgeContent.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import QueryForm from '@/components/QueryForm';
 import AnimatedResponse from '@/components/AnimatedResponse';
 import StageIndicator, { Stage } from '@/components/StageIndicator';
+import { renderWithBold } from '@/lib/renderWithBold';
 
 export default function JudgeContent() {
   const searchParams = useSearchParams();
@@ -142,7 +143,7 @@ export default function JudgeContent() {
               )}
               {streamingText && (
                 <p className="whitespace-pre-wrap text-gray-900 dark:text-gray-100">
-                  {streamingText.trimStart()}
+                  {renderWithBold(streamingText.trimStart())}
                 </p>
               )}
             </div>

--- a/src/lib/renderWithBold.tsx
+++ b/src/lib/renderWithBold.tsx
@@ -1,5 +1,5 @@
 export function renderWithBold(text: string) {
-  const parts = text.split(/\*\*(.*?)\*\*/gs);
+  const parts = text.split(/\*\*(.*?)\*\*/g);
   return parts.map((part, i) =>
     i % 2 === 1 ? <strong key={i}>{part}</strong> : part
   );

--- a/src/lib/renderWithBold.tsx
+++ b/src/lib/renderWithBold.tsx
@@ -1,0 +1,6 @@
+export function renderWithBold(text: string) {
+  const parts = text.split(/\*\*(.*?)\*\*/gs);
+  return parts.map((part, i) =>
+    i % 2 === 1 ? <strong key={i}>{part}</strong> : part
+  );
+}


### PR DESCRIPTION
## Summary
- Extracts a shared `renderWithBold()` util (`src/lib/renderWithBold.tsx`) that parses `**text**` into `<strong>` elements
- Applies it to the SSE streaming path in `JudgeContent` (the primary ruling display)
- Applies it to `AnimatedResponse` (canned/predefined responses)
- Bumps version to 1.3.2

## Test plan
- [x] Submit a real ruling query and confirm bold terms (e.g. **Special Summon**, **add**) render as bold text, not raw asterisks
- [x] Confirm canned responses (Pendulum Summon, Ash vs Called by, etc.) also render bold correctly
- [x] Confirm plain text with no `**` markers is unaffected