### PR TITLE
chore: fix build warnings and bump to v1.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "yugiai",
-    "version": "1.1.0",
+    "version": "1.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "yugiai",
-            "version": "1.1.0",
+            "version": "1.3.3",
             "dependencies": {
                 "@aws-sdk/client-bedrock-runtime": "^3.515.0",
                 "@vercel/analytics": "^1.5.0",
@@ -3442,9 +3442,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001701",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
-            "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
+            "version": "1.0.30001797",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+            "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yugiai",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
 
-export const runtime = "edge"; // Ensures it's included in Vercel deployment
-
 export async function GET() {
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">


### PR DESCRIPTION
## Summary

- **Edge runtime warning:** Removed `export const runtime = "edge"` from `sitemap.xml/route.ts` — the comment claimed it was needed for Vercel deployment but that's incorrect. Removing it lets Next.js statically generate the sitemap at build time (`○` in route table vs `ƒ` before).
- **Browserslist warning:** Updated `caniuse-lite` from `1.0.30001701` → `1.0.30001797` via `npx update-browserslist-db@latest`. No target browser changes.
- **Patch bump:** `1.3.2 → 1.3.3`

Build output is now warning-free and `/sitemap.xml` is statically generated.

> Safe to merge: yes

## Test plan

- [ ] `npm run build` produces no warnings
- [ ] Route table shows `/sitemap.xml` as `○ (Static)`
- [ ] `/sitemap.xml` returns valid XML in production